### PR TITLE
update  windows docker image tag

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -29,8 +29,8 @@ TOOLS_IMAGE=scr.sitecore.com/tools/sitecore-docker-tools-assets:10.2.0-1809
 TRAEFIK_IMAGE=traefik:v2.5.3-windowsservercore-1809
 SOLUTION_BUILD_IMAGE=mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
 SOLUTION_BASE_IMAGE=mcr.microsoft.com/windows/nanoserver:1809
-NETCORE_BUILD_IMAGE=mcr.microsoft.com/dotnet/sdk:6.0-nanoserver-ltsc2022
-NETCORE_RELEASE_IMAGE= mcr.microsoft.com/dotnet/aspnet:6.0-nanoserver-ltsc2022
+NETCORE_BUILD_IMAGE=mcr.microsoft.com/dotnet/sdk:6.0-nanoserver-1809
+NETCORE_RELEASE_IMAGE= mcr.microsoft.com/dotnet/aspnet:6.0-nanoserver-1809
 
 # Windows and Node.js version for JSS
 NODEJS_PARENT_IMAGE=mcr.microsoft.com/windows/nanoserver:1809


### PR DESCRIPTION
While setting up XM-Cloud locally, many of us getting below error

```
a Windows version 10.0.20348-based image is incompatible with a 10.0.19043 host
```

to resolve this, we need to update .env.template file and updated file will be like below

```
NETCORE_BUILD_IMAGE=mcr.microsoft.com/dotnet/sdk:6.0-nanoserver-1809
NETCORE_RELEASE_IMAGE= mcr.microsoft.com/dotnet/aspnet:6.0-nanoserver-1809
```