### PR TITLE
Updating pageTitle to Title

### DIFF
--- a/src/Project/Sugcon/SugconAnzSxa/src/Layout.tsx
+++ b/src/Project/Sugcon/SugconAnzSxa/src/Layout.tsx
@@ -19,7 +19,7 @@ const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
   return (
     <>
       <Head>
-        <title>{route?.fields?.pageTitle?.value || 'Page'}</title>
+        <title>{route?.fields?.Title?.value || 'Page'}</title>
         <link rel="icon" href={`${publicUrl}/favicon.ico`} />
       </Head>
 

--- a/src/Project/Sugcon/SugconEuSxa/src/Layout.tsx
+++ b/src/Project/Sugcon/SugconEuSxa/src/Layout.tsx
@@ -19,7 +19,7 @@ const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
   return (
     <>
       <Head>
-        <title>{route?.fields?.pageTitle?.value || 'Page'}</title>
+        <title>{route?.fields?.Title?.value || 'Page'}</title>
         <link rel="icon" href={`${publicUrl}/favicon.ico`} />
       </Head>
 


### PR DESCRIPTION
Attempt to fix page title display by accessing 'Title' using field name in Sitecore. The current code only displays the fallback 'Page' on every request, likely because the field name specified in the logic is wrong.