### PR TITLE
ANZ - Removed unnecessary sponsor categories

### DIFF
--- a/src/Project/Sugcon/items/content/Sugcon/SugconAnzSxa/Data/SponsorLists/Video Recording sponsor.yml
+++ b/src/Project/Sugcon/items/content/Sugcon/SugconAnzSxa/Data/SponsorLists/Video Recording sponsor.yml
@@ -13,17 +13,17 @@ Languages:
       Value: 20220523T075749Z
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "4884c108-8cb2-4153-8b44-7c6b67fb9395"
+      Value: "9050d0a4-885f-4a82-b268-94455b6b7825"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\xmc-e2e-admin@sitecore.com
+        sitecore\jcy@sitecore.net
     - ID: "c47a29aa-bc65-4ef2-9376-a463edd5a998"
       Hint: Sponsors
-      Value: "{DBF5F45B-74EF-4989-A64F-04B195079369}"
+      Value: 
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20220524T121633Z
+      Value: 20220906T133443Z
     - ID: "ee414f1c-1598-4d93-af66-61ce0ac6705a"
       Hint: Category
       Value: Video Recording sponsor

--- a/src/Project/Sugcon/items/content/Sugcon/SugconAnzSxa/Home/Sponsors.yml
+++ b/src/Project/Sugcon/items/content/Sugcon/SugconAnzSxa/Home/Sponsors.yml
@@ -53,36 +53,8 @@ Languages:
               s:par="GridParameters=%7B7465D855-992E-4DC2-9855-A03250DFA74B%7D&amp;FieldNames=%7B95402F44-FFA8-4753-BA19-EE20F66081FB%7D&amp;Styles&amp;CacheClearingBehavior=Clear%20on%20publish&amp;DynamicPlaceholderId=5"
               s:ph="/headless-main/container-11" />
             <r
-              uid="{84EA564A-12A0-4288-B672-C253E4C6FDC0}"
-              p:after="r[@uid='{646789C3-A3F0-4AA0-9D12-63F6984D381D}']"
-              s:ds="{EE6E86B8-774E-49D4-BD57-B6076D1EBB0D}"
-              s:id="{46D04A87-A7D0-4033-8BB9-4596465EE251}"
-              s:par="GridParameters=%7B7465D855-992E-4DC2-9855-A03250DFA74B%7D&amp;FieldNames=%7B95402F44-FFA8-4753-BA19-EE20F66081FB%7D&amp;Styles&amp;CacheClearingBehavior=Clear%20on%20publish&amp;DynamicPlaceholderId=2"
-              s:ph="/headless-main/container-11" />
-            <r
-              uid="{6EEB114A-6B53-4138-BC32-91229B76E91C}"
-              p:after="r[@uid='{84EA564A-12A0-4288-B672-C253E4C6FDC0}']"
-              s:ds="{EB25AD7E-411C-47EB-B269-8B9ACF647401}"
-              s:id="{46D04A87-A7D0-4033-8BB9-4596465EE251}"
-              s:par="GridParameters=%7B7465D855-992E-4DC2-9855-A03250DFA74B%7D&amp;FieldNames=%7B95402F44-FFA8-4753-BA19-EE20F66081FB%7D&amp;Styles&amp;CacheClearingBehavior=Clear%20on%20publish&amp;DynamicPlaceholderId=6"
-              s:ph="/headless-main/container-11" />
-            <r
-              uid="{0ECC9416-7D55-43AE-BAC8-3BAC91F17875}"
-              p:after="r[@uid='{6EEB114A-6B53-4138-BC32-91229B76E91C}']"
-              s:ds="{03F6D4C6-FD67-464F-A479-82B32F0A1614}"
-              s:id="{46D04A87-A7D0-4033-8BB9-4596465EE251}"
-              s:par="GridParameters=%7B7465D855-992E-4DC2-9855-A03250DFA74B%7D&amp;FieldNames=%7B95402F44-FFA8-4753-BA19-EE20F66081FB%7D&amp;Styles&amp;CacheClearingBehavior=Clear%20on%20publish&amp;DynamicPlaceholderId=7"
-              s:ph="/headless-main/container-11" />
-            <r
-              uid="{042D7D89-B2F6-49D5-8D0B-54E037D94090}"
-              p:after="r[@uid='{0ECC9416-7D55-43AE-BAC8-3BAC91F17875}']"
-              s:ds="{ED9C4215-415F-4CCF-AB02-05F5F5A5DA13}"
-              s:id="{46D04A87-A7D0-4033-8BB9-4596465EE251}"
-              s:par="GridParameters=%7B7465D855-992E-4DC2-9855-A03250DFA74B%7D&amp;FieldNames=%7B95402F44-FFA8-4753-BA19-EE20F66081FB%7D&amp;Styles&amp;CacheClearingBehavior=Clear%20on%20publish&amp;DynamicPlaceholderId=8"
-              s:ph="/headless-main/container-11" />
-            <r
               uid="{8833A663-91A6-4D18-872F-66F2DE584804}"
-              p:after="r[@uid='{042D7D89-B2F6-49D5-8D0B-54E037D94090}']"
+              p:after="r[@uid='{646789C3-A3F0-4AA0-9D12-63F6984D381D}']"
               s:ds="{AF76C52F-BBB3-446F-80EA-C0CDA2616249}"
               s:id="{46D04A87-A7D0-4033-8BB9-4596465EE251}"
               s:par="GridParameters=%7B7465D855-992E-4DC2-9855-A03250DFA74B%7D&amp;FieldNames=%7B95402F44-FFA8-4753-BA19-EE20F66081FB%7D&amp;Styles&amp;CacheClearingBehavior=Clear%20on%20publish&amp;DynamicPlaceholderId=9"
@@ -116,7 +88,7 @@ Languages:
       Value: Sponsors
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "d0ca905e-a831-4379-9d4e-47ee8d73c230"
+      Value: "caee70d5-225e-4c3c-8dc9-449234b7417d"
     - ID: "ba1885c7-230a-493c-a75a-9caa5e8e4d3f"
       Hint: Title
       Value: Sponsors
@@ -126,4 +98,4 @@ Languages:
         sitecore\jcy@sitecore.net
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20220830T171629Z
+      Value: 20220906T133115Z


### PR DESCRIPTION
The extra sponsor list categories copied over from SUGCON EU have been removed from the presentation details of the SUGCON ANZ Sponsors page. I have kept the lists in the data folder for future use in other years.

While in there, I also removed the 'Blastic' reference in the Video Recording sponsors list, as that was a copy from EU and not accurate for ANZ.