### PR TITLE
Added missing GitHub Action path dependencies

### DIFF
--- a/.github/workflows/CI-CD_MVP.yml
+++ b/.github/workflows/CI-CD_MVP.yml
@@ -1,20 +1,20 @@
-name: MVP Site
+name: CI-CD - MVP Site
 on: 
   workflow_dispatch:
   push:
     branches: [ main ]
     paths:
-      - 'src/**/rendering/**'
       - .github/workflows/CI-CD_MVP.yml
       - .github/workflows/build_DotNet.yml
       - .github/workflows/deploy_azureWebapp.yml
+      - 'src/**/rendering/**'
   pull_request:
     branches: [ main ]
     paths:
-      - 'src/**/rendering/**'
       - .github/workflows/CI-CD_MVP.yml
       - .github/workflows/build_DotNet.yml
       - .github/workflows/deploy_azureWebapp.yml
+      - 'src/**/rendering/**'
 
 jobs:
 

--- a/.github/workflows/CI-CD_SUGCON_ANZ.yml
+++ b/.github/workflows/CI-CD_SUGCON_ANZ.yml
@@ -5,11 +5,15 @@ on:
     branches: [ main ]
     paths:
       - .github/workflows/CI-CD_SUGCON_ANZ.yml
+      - .github/workflows/build_NextJs.yml
+      - .github/workflows/deploy_vercel.yml
       - 'src/Project/Sugcon/SugconAnzSxa/**'
   pull_request:
     branches: [ main ]
     paths:
       - .github/workflows/CI-CD_SUGCON_ANZ.yml
+      - .github/workflows/build_NextJs.yml
+      - .github/workflows/deploy_vercel.yml
       - 'src/Project/Sugcon/SugconAnzSxa/**'
 
 jobs:

--- a/.github/workflows/CI-CD_SUGCON_ANZ.yml
+++ b/.github/workflows/CI-CD_SUGCON_ANZ.yml
@@ -1,4 +1,4 @@
-name: SUGCON ANZ
+name: CI-CD - SUGCON ANZ
 on: 
   workflow_dispatch:
   push:

--- a/.github/workflows/CI-CD_SUGCON_EU.yml
+++ b/.github/workflows/CI-CD_SUGCON_EU.yml
@@ -1,4 +1,4 @@
-name: SUGCON EU
+name: CI-CD - SUGCON EU
 on: 
   workflow_dispatch:
   push:

--- a/.github/workflows/CI-CD_SUGCON_EU.yml
+++ b/.github/workflows/CI-CD_SUGCON_EU.yml
@@ -5,11 +5,15 @@ on:
     branches: [ main ]
     paths:
       - .github/workflows/CI-CD_SUGCON_EU.yml
+      - .github/workflows/build_NextJs.yml
+      - .github/workflows/deploy_vercel.yml
       - 'src/Project/Sugcon/SugconEuSxa/**'
   pull_request:
     branches: [ main ]
     paths:
       - .github/workflows/CI-CD_SUGCON_EU.yml
+      - .github/workflows/build_NextJs.yml
+      - .github/workflows/deploy_vercel.yml
       - 'src/Project/Sugcon/SugconEuSxa/**'
 
 jobs:

--- a/.github/workflows/CI-CD_XM_Cloud.yml
+++ b/.github/workflows/CI-CD_XM_Cloud.yml
@@ -6,6 +6,7 @@ on:
     paths:
     - .github/workflows/CI-CD_XM_Cloud.yml
     - .github/workflows/deploy_xmCloud.yml
+    - .github/workflows/build_DotNet.yml
     - 'xmlcloud.build.json'
     - 'src/**/platform/**'
     - 'src/**/items/**'
@@ -14,6 +15,7 @@ on:
     paths:
     - .github/workflows/CI-CD_XM_Cloud.yml
     - .github/workflows/deploy_xmCloud.yml
+    - .github/workflows/build_DotNet.yml
     - 'xmlcloud.build.json'
     - 'src/**/platform/**'
     - 'src/**/items/**'

--- a/.github/workflows/CI-CD_XM_Cloud.yml
+++ b/.github/workflows/CI-CD_XM_Cloud.yml
@@ -1,4 +1,4 @@
-name: XM Cloud
+name: CI-CD - XM Cloud
 on: 
   workflow_dispatch:
   push:

--- a/.github/workflows/build_NextJs.yml
+++ b/.github/workflows/build_NextJs.yml
@@ -1,4 +1,4 @@
-name: Build the DotNet Solution
+name: Build a Nextjs Application
 
 on:
   workflow_call:

--- a/.github/workflows/deploy_azureWebapp.yml
+++ b/.github/workflows/deploy_azureWebapp.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup .NET Core
+      - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 6.0.300

--- a/.github/workflows/deploy_xmCloud.yml
+++ b/.github/workflows/deploy_xmCloud.yml
@@ -45,7 +45,7 @@ jobs:
             exit -1
         fi
         echo "Deployment Completed"
-    - name: Connect the CLI to the Environment
+    - name: Connect to XM Cloud CM instance
       run: dotnet sitecore cloud environment connect -id ${{ secrets.XM_CLOUD_ENVIRONMENT_ID }} --allow-write
     - name: Publish content changes
       run: dotnet sitecore publish --pt Edge -n ${{ inputs.environmentName }}


### PR DESCRIPTION
Tidied up a series of things with the GitHub Actions workflow
- Added missing Path dependencies, to ensure changes to template workflows cause builds
- Fixed a few incorrect labels
- Rearranged MVP paths to match path order from other workflows
- Updated CI-CD Workflow naming to match yml files for consistency.