### PR TITLE
Accept language header error

### DIFF
--- a/src/Project/MvpSite/rendering/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Project/MvpSite/rendering/Extensions/ApplicationBuilderExtensions.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Mvp.Project.MvpSite.Middleware;
+
+namespace Mvp.Project.MvpSite.Extensions
+{
+    public static class ApplicationBuilderExtensions
+    {
+        public static IApplicationBuilder EnsureAcceptLanguageHeader(this IApplicationBuilder app)
+        {
+            app.UseMiddleware<EnsureAcceptLanguageHeaderMiddleware>();
+            return app;
+        }
+    }
+}

--- a/src/Project/MvpSite/rendering/Middleware/EnsureAcceptLanguageHeaderMiddleware.cs
+++ b/src/Project/MvpSite/rendering/Middleware/EnsureAcceptLanguageHeaderMiddleware.cs
@@ -9,13 +9,6 @@ namespace Mvp.Project.MvpSite.Middleware
         private readonly RequestDelegate next;
         private readonly IConfiguration configuration;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RenderingEngineMiddleware"/> class.
-        /// </summary>
-        /// <param name="next">The next middleware to call.</param>
-        /// <param name="requestMapper">The <see cref="ISitecoreLayoutRequestMapper"/> to map the HttpRequest to a Layout Service request.</param>
-        /// <param name="layoutService">The layout service client.</param>
-        /// <param name="options">Rendering Engine options.</param>
         public EnsureAcceptLanguageHeaderMiddleware(RequestDelegate next, IConfiguration configuration)
         {
             this.next = next;

--- a/src/Project/MvpSite/rendering/Middleware/EnsureAcceptLanguageHeaderMiddleware.cs
+++ b/src/Project/MvpSite/rendering/Middleware/EnsureAcceptLanguageHeaderMiddleware.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using System.Threading.Tasks;
+
+namespace Mvp.Project.MvpSite.Middleware
+{
+    public class EnsureAcceptLanguageHeaderMiddleware
+    {
+        private readonly RequestDelegate next;
+        private readonly IConfiguration configuration;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RenderingEngineMiddleware"/> class.
+        /// </summary>
+        /// <param name="next">The next middleware to call.</param>
+        /// <param name="requestMapper">The <see cref="ISitecoreLayoutRequestMapper"/> to map the HttpRequest to a Layout Service request.</param>
+        /// <param name="layoutService">The layout service client.</param>
+        /// <param name="options">Rendering Engine options.</param>
+        public EnsureAcceptLanguageHeaderMiddleware(RequestDelegate next, IConfiguration configuration)
+        {
+            this.next = next;
+            this.configuration = configuration;
+        }
+
+        public async Task Invoke(HttpContext httpContext)
+        {
+            if (!httpContext.Request.Headers.ContainsKey("Accept-Language"))
+            {
+                var defaultLang = configuration.GetValue<string>("DefaultAcceptLanguageHeader");
+                httpContext.Request.Headers.Add("Accept-Language", defaultLang);
+            }
+
+            await next(httpContext).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Project/MvpSite/rendering/Startup.cs
+++ b/src/Project/MvpSite/rendering/Startup.cs
@@ -15,6 +15,7 @@ using Mvp.Feature.Selections.Extensions;
 using Mvp.Feature.Social.Extensions;
 using Mvp.Feature.User.Extensions;
 using Mvp.Foundation.Configuration.Rendering.AppSettings;
+using Mvp.Project.MvpSite.Extensions;
 using Sitecore.AspNet.ExperienceEditor;
 using Sitecore.AspNet.RenderingEngine.Extensions;
 using Sitecore.AspNet.RenderingEngine.Localization;
@@ -115,6 +116,7 @@ namespace Mvp.Project.MvpSite.Rendering
                 app.UseSitecoreExperienceEditor();
 
             // Standard ASP.NET Core routing and static file support.
+            app.EnsureAcceptLanguageHeader();
             app.UseRouting();
             app.UseStaticFiles();
 

--- a/src/Project/MvpSite/rendering/appsettings.json
+++ b/src/Project/MvpSite/rendering/appsettings.json
@@ -9,5 +9,6 @@
     "MvpApplicationListsDataGraphQLQueryCacheTimeout": 5
   },
   "AllowedHosts": "*",
-  "https_port": 443
+  "https_port": 443,
+  "DefaultAcceptLanguageHeader": "en"
 } 


### PR DESCRIPTION
This is a fix for a bug in the ASP.NET Rendering SDK, where a 404 is thrown if the Accept-Language header isn't included in the main request to load the page.

Tracked internally as `Bug 555373`

closes #163 