### PR TITLE
Updated GitHub Actions template to not do deploys for PRs

### DIFF
--- a/.github/workflows/CI-CD_MVP.yml
+++ b/.github/workflows/CI-CD_MVP.yml
@@ -25,7 +25,8 @@ jobs:
 
   deploy-mvp-staging:
     uses: ./.github/workflows/deploy_azureWebapp.yml
-    needs: build-dotnet 
+    needs: build-dotnet
+    if: github.repository_owner == 'Sitecore' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push')) 
     with:
       buildConfiguration: Debug
       projectLocation: src/Project/MvpSite/rendering

--- a/.github/workflows/CI-CD_SUGCON_ANZ.yml
+++ b/.github/workflows/CI-CD_SUGCON_ANZ.yml
@@ -32,9 +32,9 @@ jobs:
 
   deploy-staging-anz-site:
     uses: ./.github/workflows/deploy_vercel.yml
-    if: github.repository_owner == 'Sitecore' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
     needs: [build-staging-anz-site, build-production-anz-site]
     if: always() && 
+        github.repository_owner == 'Sitecore' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
         needs.build-staging-anz-site.result != 'failure' &&
         needs.build-staging-anz-site.result != 'cancelled' && 
         needs.build-production-anz-site.result != 'failure' &&

--- a/.github/workflows/CI-CD_SUGCON_ANZ.yml
+++ b/.github/workflows/CI-CD_SUGCON_ANZ.yml
@@ -32,6 +32,7 @@ jobs:
 
   deploy-staging-anz-site:
     uses: ./.github/workflows/deploy_vercel.yml
+    if: github.repository_owner == 'Sitecore' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
     needs: [build-staging-anz-site, build-production-anz-site]
     if: always() && 
         needs.build-staging-anz-site.result != 'failure' &&

--- a/.github/workflows/CI-CD_SUGCON_ANZ.yml
+++ b/.github/workflows/CI-CD_SUGCON_ANZ.yml
@@ -34,7 +34,7 @@ jobs:
     uses: ./.github/workflows/deploy_vercel.yml
     needs: [build-staging-anz-site, build-production-anz-site]
     if: always() && 
-        github.repository_owner == 'Sitecore' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
+        (github.repository_owner == 'Sitecore' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))) &&
         needs.build-staging-anz-site.result != 'failure' &&
         needs.build-staging-anz-site.result != 'cancelled' && 
         needs.build-production-anz-site.result != 'failure' &&

--- a/.github/workflows/CI-CD_SUGCON_EU.yml
+++ b/.github/workflows/CI-CD_SUGCON_EU.yml
@@ -34,7 +34,7 @@ jobs:
     uses: ./.github/workflows/deploy_vercel.yml
     needs: [build-staging-eu-site, build-production-eu-site]
     if: always() && 
-        github.repository_owner == 'Sitecore' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
+        (github.repository_owner == 'Sitecore' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))) &&
         needs.build-staging-anz-site.result != 'failure' &&
         needs.build-staging-anz-site.result != 'cancelled' && 
         needs.build-production-anz-site.result != 'failure' &&

--- a/.github/workflows/CI-CD_SUGCON_EU.yml
+++ b/.github/workflows/CI-CD_SUGCON_EU.yml
@@ -32,6 +32,7 @@ jobs:
 
   deploy-eu-site:
     uses: ./.github/workflows/deploy_vercel.yml
+    if: github.repository_owner == 'Sitecore' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
     needs: [build-staging-eu-site, build-production-eu-site]
     if: always() && 
         needs.build-staging-eu-site.result != 'failure' &&

--- a/.github/workflows/CI-CD_SUGCON_EU.yml
+++ b/.github/workflows/CI-CD_SUGCON_EU.yml
@@ -32,13 +32,13 @@ jobs:
 
   deploy-eu-site:
     uses: ./.github/workflows/deploy_vercel.yml
-    if: github.repository_owner == 'Sitecore' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
     needs: [build-staging-eu-site, build-production-eu-site]
     if: always() && 
-        needs.build-staging-eu-site.result != 'failure' &&
-        needs.build-staging-eu-site.result != 'cancelled' && 
-        needs.build-production-eu-site.result != 'failure' &&
-        needs.build-production-eu-site.result != 'cancelled'
+        github.repository_owner == 'Sitecore' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
+        needs.build-staging-anz-site.result != 'failure' &&
+        needs.build-staging-anz-site.result != 'cancelled' && 
+        needs.build-production-anz-site.result != 'failure' &&
+        needs.build-production-anz-site.result != 'cancelled'
     secrets:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/CI-CD_SUGCON_Events.yml
+++ b/.github/workflows/CI-CD_SUGCON_Events.yml
@@ -20,6 +20,7 @@ jobs:
 
   deploy-events-site:
     uses: ./.github/workflows/deploy_vercel.yml
+    if: github.repository_owner == 'Sitecore' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
     secrets:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/CI-CD_XM_Cloud.yml
+++ b/.github/workflows/CI-CD_XM_Cloud.yml
@@ -29,6 +29,7 @@ jobs:
 
   deploy-staging:
     uses: ./.github/workflows/deploy_xmCloud.yml
+    if: github.repository_owner == 'Sitecore' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
     needs: build-dotnet 
     with:
       environmentName: Staging


### PR DESCRIPTION
PRs from Forks are building successfully, but are failing deploys due to a lack of access to Secrets. This PR disabled deployments for any PR's that are submitted from a Fork.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.