### PR TITLE
#170-Invalid-Template-error: remove $  and other spl chars from the a…

### DIFF
--- a/init.ps1
+++ b/init.ps1
@@ -144,8 +144,8 @@ if ($InitEnv) {
 	Set-EnvFileVariable "CM_HOST" -Value $CM_Host
 	Set-EnvFileVariable "MVP_RENDERING_HOST" -Value $MVP_Host
 	Set-EnvFileVariable "REPORTING_API_KEY" -Value (Get-SitecoreRandomString 128 -DisallowSpecial)
-	Set-EnvFileVariable "TELERIK_ENCRYPTION_KEY" -Value (Get-SitecoreRandomString 128)
-	Set-EnvFileVariable "MEDIA_REQUEST_PROTECTION_SHARED_SECRET" -Value (Get-SitecoreRandomString 64)
+	Set-EnvFileVariable "TELERIK_ENCRYPTION_KEY" -Value (Get-SitecoreRandomString 128 -DisallowSpecial)
+	Set-EnvFileVariable "MEDIA_REQUEST_PROTECTION_SHARED_SECRET" -Value (Get-SitecoreRandomString 64 -DisallowSpecial)
 	Set-EnvFileVariable "SQL_SA_PASSWORD" -Value (Get-SitecoreRandomString 19 -DisallowSpecial -EnforceComplexity)
     Set-EnvFileVariable "SQL_SERVER" -Value "mssql"
     Set-EnvFileVariable "SQL_SA_LOGIN" -Value "sa"


### PR DESCRIPTION
Invalid-Template-error: remove $  and other spl chars from the autogenerated random string

<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation

<!--- Describe your changes in detail -->
Removes $ character from generated random string for .env file keys
<!--- Why is this change required? What problem does it solve? -->
To resolve invalid template error on up.ps1 
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/Sitecore/XM-Cloud-Introduction/issues/170

## How Has This Been Tested?
run .\init.ps1 -initEnv -licensexmlpath c:\license\license.xml -adminpassword b
run .\up.ps1

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have read the Contributing guide.
- [x ] My code/comments/docs fully adhere to the Code of Conduct.
- [x ] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.