### PR TITLE
Fixed issue with logic for facets on MVP Listing page

### DIFF
--- a/src/Feature/People/rendering/PeopleFinder/MvpFinder.cs
+++ b/src/Feature/People/rendering/PeopleFinder/MvpFinder.cs
@@ -1,4 +1,5 @@
 ﻿using GraphQL.Client.Abstractions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -78,9 +79,18 @@ namespace Mvp.Feature.People.PeopleFinder
 
         private static bool DoesMvpMatchSelectedFacets(string[] selectedAwards, string[] selectedYears, string[] selectedCountries, MvpSearchResult mvp)
         {
-            return MvpMatchesAwardTypeFacet(selectedAwards, mvp) 
-                && MvpMatchesYearFacet(selectedYears, mvp) 
-                && MvpMatchesCountryFacet(selectedCountries, mvp);
+            if(!MvpMatchesCountryFacet(selectedCountries, mvp))
+            {
+                return false;
+            }
+
+            foreach(var award in mvp.Awards.TargetItems)
+            {
+                if (AwardMatchesYearFacet(selectedYears, award) && AwardMatchesAwardTypeFacet(selectedAwards, award))
+                    return true;
+            }
+
+            return false;
         }
 
         private static bool MvpMatchesCountryFacet(string[] selectedCountries, MvpSearchResult mvp)
@@ -89,16 +99,16 @@ namespace Mvp.Feature.People.PeopleFinder
                 || selectedCountries.Any(x => x.ToLowerInvariant() == mvp.Country.TargetItem?.Name.ToLowerInvariant());
         }
 
-        private static bool MvpMatchesYearFacet(string[] selectedYears, MvpSearchResult mvp)
+        private static bool AwardMatchesYearFacet(string[] selectedYears, Awards award)
         {
-            return selectedYears.Length == 0 
-                || mvp.Awards.TargetItems.Any(x => selectedYears.Any(y => y.ToLowerInvariant() == x.Parent.Name.ToLowerInvariant()));
+            return selectedYears.Length == 0
+                || selectedYears.Any(y => y.ToLowerInvariant() == award.Parent.Name.ToLowerInvariant());
         }
 
-        private static bool MvpMatchesAwardTypeFacet(string[] selectedAwards, MvpSearchResult mvp)
+        private static bool AwardMatchesAwardTypeFacet(string[] selectedAwards, Awards award)
         {
-            return selectedAwards.Length == 0 
-                || mvp.Awards.TargetItems.Any(x => selectedAwards.Any(y => y.ToLowerInvariant() == x.Field.TargetItem.Field.Value.ToLowerInvariant()));
+            return selectedAwards.Length == 0
+                || selectedAwards.Any(y => y.ToLowerInvariant() == award.Field.TargetItem.Field.Value.ToLowerInvariant());
         }
 
         private IList<MvpSearchResult> ApplyFilteringToMvpListing(IList<MvpSearchResult> mvps, SearchParams searchParams)


### PR DESCRIPTION
Currently the logic for the matching the search factes on the MVP Listing Page is incorrect, it currently checks whether any of an MVP's awards match the facets individually.

This causes an issue when selecting both year & type, e.g. if you select 2023 and Technology and MVP who received 2022 Technology and 2023 Ambassador would be returned as they have an award that matches 2023 and an awards that matches Technology..... just not an award that matches both.

This changes the logic to iterate an MVP's awards an ensure that both facets in a single award when multiple are selected.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.

Closes #232 