### PR TITLE
Fixed issue with fullname search on MVP listing page

### DIFF
--- a/src/Feature/People/rendering/PeopleFinder/MvpFinder.cs
+++ b/src/Feature/People/rendering/PeopleFinder/MvpFinder.cs
@@ -103,8 +103,14 @@ namespace Mvp.Feature.People.PeopleFinder
 
         private IList<MvpSearchResult> ApplyFilteringToMvpListing(IList<MvpSearchResult> mvps, SearchParams searchParams)
         {
-            var keyword = string.IsNullOrWhiteSpace(searchParams.Keyword) ? searchParams.Keyword : searchParams.Keyword.ToLowerInvariant();
-            return mvps.Where(x => string.IsNullOrWhiteSpace(searchParams.Keyword) || x.FirstName.Value.ToLowerInvariant().Contains(keyword) || x.LastName.Value.ToLowerInvariant().Contains(keyword)).ToList();
+            return mvps.Where(
+                mvp => string.IsNullOrWhiteSpace(searchParams.Keyword) ||
+                DoesMvpFullnameMatchKeywords(searchParams.Keyword, mvp)).ToList();
+        }
+
+        private static bool DoesMvpFullnameMatchKeywords(string keyword, MvpSearchResult x)
+        {
+            return $"{x.FirstName.Value.ToLowerInvariant()}{x.LastName.Value.ToLowerInvariant()}".Contains(keyword.ToLowerInvariant().Replace(" ", string.Empty));
         }
 
         private static Person GeneratePersonRecord(MvpSearchResult mvpSearchResult)


### PR DESCRIPTION
Currently it's not possible to search for the term "Firstname Lastname" on the MVP Directory as it matches the full string against both the firstname and lastname fields.

This PR changes the logic to combine the Firstname & Lastname fields and compare them to the full string entered. We also strip whitespace out of the string before comparison to help with accidental double spaces causing non-matching.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.

Closes #231 