### PR TITLE
NETCORE_BUILD_IMAGE and NETCORE_RELEASE_IMAGE tags version updated to…

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -29,8 +29,8 @@ TOOLS_IMAGE=scr.sitecore.com/tools/sitecore-docker-tools-assets:10.2.0-1809
 TRAEFIK_IMAGE=traefik:v2.5.3-windowsservercore-1809
 SOLUTION_BUILD_IMAGE=mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
 SOLUTION_BASE_IMAGE=mcr.microsoft.com/windows/nanoserver:1809
-NETCORE_BUILD_IMAGE=mcr.microsoft.com/dotnet/sdk:6.0-nanoserver-ltsc2022
-NETCORE_RELEASE_IMAGE= mcr.microsoft.com/dotnet/aspnet:6.0-nanoserver-ltsc2022
+NETCORE_BUILD_IMAGE=mcr.microsoft.com/dotnet/sdk:6.0-nanoserver-1809
+NETCORE_RELEASE_IMAGE= mcr.microsoft.com/dotnet/aspnet:6.0-nanoserver-1809
 
 # Windows and Node.js version for JSS
 NODEJS_PARENT_IMAGE=mcr.microsoft.com/windows/nanoserver:1809


### PR DESCRIPTION
Fix For the issue 240

<!--- Provide a general summary of your changes in the Title above -->
I tried spinning up the containers in my local machine to check the XM Cloud. When I run ./up.ps1 I faced issue "Windows version 10.0.20348-based image is incompatible with a 10.0.19044 host"

## Description / Motivation

<!--- Describe your changes in detail -->
Updated the image tags version in .env.template.
<!--- Why is this change required? What problem does it solve? -->
After updating the tags to 1809 the issue has been resolved and I am able to successfully spin up the containers and able to access XM Cloud in my local
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/Sitecore/XM-Cloud-Introduction/issues/240

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
spin up the containers using the commands mentioned here https://github.com/Sitecore/XM-Cloud-Introduction#-running-in-full-local-development-mode
<!--- Include details of your testing environment, and the tests you ran to -->
Tested in Azure VM running in Windows 10, 16 GB Ram and 4 vCPUs
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.