### PR TITLE
Simplification of the SUGCON ANZ & EU Deployment definitions

### DIFF
--- a/.github/workflows/CI-CD_SUGCON_ANZ.yml
+++ b/.github/workflows/CI-CD_SUGCON_ANZ.yml
@@ -18,21 +18,15 @@ on:
 
 jobs:
 
-  build-staging-anz-site:
+  build-anz-site:
     if: github.ref != 'refs/heads/main'
-    uses: ./.github/workflows/build_NextJs.yml
-    with:
-      workingDirectory: ./src/Project/Sugcon/SugconAnzSxa
-
-  build-production-anz-site:
-    if: github.ref == 'refs/heads/main'
     uses: ./.github/workflows/build_NextJs.yml
     with:
       workingDirectory: ./src/Project/Sugcon/SugconAnzSxa
 
   deploy-staging-anz-site:
     uses: ./.github/workflows/deploy_vercel.yml
-    needs: [build-staging-anz-site, build-production-anz-site]
+    needs: build-anz-site
     if: always() && 
         (github.repository_owner == 'Sitecore' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))) &&
         needs.build-staging-anz-site.result != 'failure' &&

--- a/.github/workflows/CI-CD_SUGCON_EU.yml
+++ b/.github/workflows/CI-CD_SUGCON_EU.yml
@@ -18,21 +18,15 @@ on:
 
 jobs:
 
-  build-staging-eu-site:
+  build-eu-site:
     if: github.ref != 'refs/heads/main'
-    uses: ./.github/workflows/build_NextJs.yml
-    with:
-      workingDirectory: ./src/Project/Sugcon/SugconEuSxa
-    
-  build-production-eu-site:
-    if: github.ref == 'refs/heads/main'  
     uses: ./.github/workflows/build_NextJs.yml
     with:
       workingDirectory: ./src/Project/Sugcon/SugconEuSxa
 
   deploy-eu-site:
     uses: ./.github/workflows/deploy_vercel.yml
-    needs: [build-staging-eu-site, build-production-eu-site]
+    needs: build-eu-site
     if: always() && 
         (github.repository_owner == 'Sitecore' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))) &&
         needs.build-staging-anz-site.result != 'failure' &&


### PR DESCRIPTION
This change should have been made as part of [e869a17] . That changed the Vercel deploys to no longer generate as part of the build step, and to only do a build. This means we no longer need the separate builds for Prod vs Staging build.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.