### PR TITLE
Automate 'Edge Development mode with No Docker'

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Examples of how to use them can be seen in the different setup guides for both L
 | SUCGON_INDIA_CDP_CLIENT_KEY  | No                    | No                        | CDP Client key for SUGCON India Site                            |
 | SUCGON_INDIA_CDP_TARGET_URL  | No                    | No                        | CDP Target URL for SUGCON India Site                            |
 | SUCGON_INDIA_CDP_POINTOFSALE | No                    | No                        | CDP POS for SUGCON India Site                                   |
+| EdgeNoDocker                 | No                    | No                        | Used to initialise the repo for Edge Developer without Docker   |
+
 
 ## Embeded Personalisation
 Embedded Personalisation is disabled locally by default. If you wish to enable it you will need to populate the different `xx_CDP_CLIENT_KEY`, `xx_CDP_TARGET_URL` & `xx_CDP_POINTOFSALE` parameters with valid values and change the `NODE_ENV` parameter from `development` to another value.
@@ -98,7 +100,7 @@ Next, use the `up.ps1` script to bring up all of the containers required for Loc
 ## 🐋+🌏 Running in Edge Development Mode with Docker
 Running in Edge Mode with Docker will run only run the Head applications and Traefik. To be able to run the sites in this repository locally against Edge, you will need to have access to an active XM Cloud Subscription with enough entitlements to be able to create a new Project & Environment to run against.
 
-## Create a new environment and deploy the codebase
+### Create a new environment and deploy the codebase
 You can follow these steps to create a new XM Cloud Project & Environment, then generate an Edge Token used to authenticate your Head applications with your Edge Tenant.
 - Authenticate with the XM Cloud Deploy Application
   - `dotnet sitecore cloud login`
@@ -121,10 +123,10 @@ If you want more information about the Cloud plugin for the CLI then you access 
 First initialize your repo using the `.init/ps1` script, you will need to pass in the `-Edge_Token` parameter set to the value you generated in the previous step.
 
 ```ps1
-.\init.ps1 -InitEnv -LicenseXmlPath "C:\path\to\license.xml" -AdminPassword "DesiredAdminPassword" --Edge_Token "<<YOUR_EDGE_TOKEN>>"
+.\init.ps1 -InitEnv -LicenseXmlPath "C:\path\to\license.xml" -AdminPassword "DesiredAdminPassword" -Edge_Token "<<YOUR_EDGE_TOKEN>>"
 ```
 
-## Bring up all the application elements for Edge Mode with Docker
+### Bring up all the application elements for Edge Mode with Docker
 Once you have initialized the repository with your Edge Token, use the `up.ps1` script, ensuring to pass the `-UseEdge` parameter to bring up all of the containers required for Edge Mode.
 
 ```ps1
@@ -132,4 +134,19 @@ Once you have initialized the repository with your Edge Token, use the `up.ps1` 
 ```
 
 ## 💻+🌏 Running in Edge Development Mode without Docker
-Coming soon...
+
+### Initialize your repository for Edge Development Mode with Docker
+First initialize your repo using the `.init/ps1` script, you will need to pass in the `-Edge_Token` & `-EdgeNoDocker` parameters to ensure that the repository is correct initialised.
+
+```ps1
+.\init.ps1 -InitEnv -LicenseXmlPath "C:\path\to\license.xml" -AdminPassword "DesiredAdminPassword" -Edge_Token "<<YOUR_EDGE_TOKEN>>" - EdgeNoDocker
+```
+
+Running with the `-EdgeNoDocker` switch, will setup configuration files for each of the heads included in this repository. You can then manually run each of them using either NPM or DotNet.
+
+### Running the MVP Site
+
+After completing the init setup above you will be able to run the MVP Site either directly from within Visual Studio, or by using the DotNet CLI.
+
+- To run from within Visual Studio, open the `src\XmCloudIntroduction.sln`, ensure that the `Mvp.Project.MvpSite.Rendering` project is set as your StartUp Project, then hit F5.
+- To run from the DotNet CLI, open a new terminal window and navigate to the `src\Project\MvpSite\rendering` folder, then run `dotnet run`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repository contains the codebase for a series of sites managed by the Techn
 # ✋ Prerequisites
 - [DotNet 6.0](https://dotnet.microsoft.com/en-us/download)
 - [NodeJS 16 LTS](https://nodejs.org/en/download/) (or greater)
-- [Docker](https://www.docker.com/)
+- [Docker](https://www.docker.com/) (Not required when running in Edge Development Mode without Docker)
 
 ## Docker Compose v2
 This repository uses Docker Compose v2. As of June 2023 v1 is no longer supported by Docker. You can read more about the differences between the two versions [here](https://docs.docker.com/compose/compose-v2/).
@@ -34,31 +34,32 @@ If you wish to run the MVP Site you will need to provide Okta configuration deta
 When you interact with XM Cloud you will be asked to authenticate with our Auth0 tenant. If you don't have an account already you can follow the registration flow provided by the Auth0 to create one.
 
 # ▶️ Initializing the repository
-You first need to initialize your .env file which will configure how the different application elements will run. There are a series of parameters you can pass in to override the default behaviour of the application, you can find the full list of parameters with their purpose here.
+You first need to initialize the repository, which will configure how the different application elements will run. There are a series of parameters you can pass into the `init.ps1` script to achieve this, you can find the full list of parameters with their purpose here.
 
-Examples of how to use them can be seen in the different setup guides for both Local Mode and Edge Mode below.
+You must be in "administrator mode" to run the `init.ps1` script.
 
-| Parameter                    | Required for MVP Site | Required for SUGCON Sites | Purpose                                                         |
-|------------------------------|-----------------------|---------------------------|-----------------------------------------------------------------|
-| LicenseXmlPath               | **Yes**               | **Yes**                   | Used to specify the path to the license file                    |
-| AdminPassword                | **Yes**               | **Yes**                   | Used to specify the password for the Sitecore admin user        |
-| InitEnv                      | No                    | No                        | Used to force a full initialisation of the repository           |
-| Edge_Token                   | No                    | No                        | Used to authenticate with XM Cloud, when running in 'Edge Mode' |
-| OKTA_Domain                  | **Yes**               | No                        | Okta domain used by the MVP Rendering host                      |
-| OKTA_Client_Id               | **Yes**               | No                        | Okta Client Id used by the MVP Rendering host                   |
-| OKTA_Client_Secret           | **Yes**               | No                        | Okta Client Secret used by the MVP Rendering host               |
-| MVP_Selections_API           | **Yes**               | No                        | URL for the MVP Selections API                                  |
-| SUCGON_ANZ_CDP_CLIENT_KEY    | No                    | No                        | CDP Client key for SUGCON ANZ Site                              |
-| SUCGON_ANZ_CDP_TARGET_URL    | No                    | No                        | CDP Target URL for SUGCON ANZ Site                              |
-| SUCGON_ANZ_CDP_POINTOFSALE   | No                    | No                        | CDP POS for SUGCON ANZ Site                                     |
-| SUCGON_EU_CDP_CLIENT_KEY     | No                    | No                        | CDP Client key for SUGCON EU Site                               |
-| SUCGON_EU_CDP_TARGET_URL     | No                    | No                        | CDP Target URL for SUGCON EU Site                               |
-| SUCGON_EU_CDP_POINTOFSALE    | No                    | No                        | CDP POS for SUGCON EU Site                                      |
-| SUCGON_INDIA_CDP_CLIENT_KEY  | No                    | No                        | CDP Client key for SUGCON India Site                            |
-| SUCGON_INDIA_CDP_TARGET_URL  | No                    | No                        | CDP Target URL for SUGCON India Site                            |
-| SUCGON_INDIA_CDP_POINTOFSALE | No                    | No                        | CDP POS for SUGCON India Site                                   |
-| EdgeNoDocker                 | No                    | No                        | Used to initialise the repo for Edge Developer without Docker   |
+Examples of how to use them can be seen in the setup guides for the different running modes below .
 
+| Parameter                    | Required for MVP Site | Required for SUGCON Sites | Required for full local | Required for Edge Mode | Purpose                                                         |
+|------------------------------|-----------------------|---------------------------|-------------------------|------------------------|-----------------------------------------------------------------|
+| LicenseXmlPath               | No                    | No                        | **Yes**                 | No                     | Used to specify the path to the license file                    |
+| AdminPassword                | No                    | No                        | **Yes**                 | No                     | Used to specify the password for the Sitecore admin user        |
+| InitEnv                      | No                    | No                        | No                      | No                     | Used to force a full initialisation of the repository           |
+| Edge_Token                   | No                    | No                        | No                      | **Yes**                | Used to authenticate with XM Cloud, when running in 'Edge Mode' |
+| OKTA_Domain                  | **Yes**               | No                        | No                      | No                     | Okta domain used by the MVP Rendering host                      |
+| OKTA_Client_Id               | **Yes**               | No                        | No                      | No                     | Okta Client Id used by the MVP Rendering host                   |
+| OKTA_Client_Secret           | **Yes**               | No                        | No                      | No                     | Okta Client Secret used by the MVP Rendering host               |
+| MVP_Selections_API           | No                    | No                        | No                      | No                     | URL for the MVP Selections API                                  |
+| SUCGON_ANZ_CDP_CLIENT_KEY    | No                    | No                        | No                      | No                     | CDP Client key for SUGCON ANZ Site                              |
+| SUCGON_ANZ_CDP_TARGET_URL    | No                    | No                        | No                      | No                     | CDP Target URL for SUGCON ANZ Site                              |
+| SUCGON_ANZ_CDP_POINTOFSALE   | No                    | No                        | No                      | No                     | CDP POS for SUGCON ANZ Site                                     |
+| SUCGON_EU_CDP_CLIENT_KEY     | No                    | No                        | No                      | No                     | CDP Client key for SUGCON EU Site                               |
+| SUCGON_EU_CDP_TARGET_URL     | No                    | No                        | No                      | No                     | CDP Target URL for SUGCON EU Site                               |
+| SUCGON_EU_CDP_POINTOFSALE    | No                    | No                        | No                      | No                     | CDP POS for SUGCON EU Site                                      |
+| SUCGON_INDIA_CDP_CLIENT_KEY  | No                    | No                        | No                      | No                     | CDP Client key for SUGCON India Site                            |
+| SUCGON_INDIA_CDP_TARGET_URL  | No                    | No                        | No                      | No                     | CDP Target URL for SUGCON India Site                            |
+| SUCGON_INDIA_CDP_POINTOFSALE | No                    | No                        | No                      | No                     | CDP POS for SUGCON India Site                                   |
+| Edge_NoDocker                | No                    | No                        | No                      | No                     | Used to initialise the repo for Edge Developer without Docker   |
 
 ## Embeded Personalisation
 Embedded Personalisation is disabled locally by default. If you wish to enable it you will need to populate the different `xx_CDP_CLIENT_KEY`, `xx_CDP_TARGET_URL` & `xx_CDP_POINTOFSALE` parameters with valid values and change the `NODE_ENV` parameter from `development` to another value.
@@ -139,7 +140,7 @@ Once you have initialized the repository with your Edge Token, use the `up.ps1` 
 First initialize your repo using the `.init/ps1` script, you will need to pass in the `-Edge_Token` & `-EdgeNoDocker` parameters to ensure that the repository is correct initialised.
 
 ```ps1
-.\init.ps1 -InitEnv -LicenseXmlPath "C:\path\to\license.xml" -AdminPassword "DesiredAdminPassword" -Edge_Token "<<YOUR_EDGE_TOKEN>>" -EdgeNoDocker
+.\init.ps1 -InitEnv -Edge_Token "<<YOUR_EDGE_TOKEN>>" -Edge_NoDocker
 ```
 
 Running with the `-EdgeNoDocker` switch, will setup configuration files for each of the heads included in this repository. You can then manually run each of them using either NPM or DotNet.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Once you have initialized the repository with your Edge Token, use the `up.ps1` 
 First initialize your repo using the `.init/ps1` script, you will need to pass in the `-Edge_Token` & `-EdgeNoDocker` parameters to ensure that the repository is correct initialised.
 
 ```ps1
-.\init.ps1 -InitEnv -LicenseXmlPath "C:\path\to\license.xml" -AdminPassword "DesiredAdminPassword" -Edge_Token "<<YOUR_EDGE_TOKEN>>" - EdgeNoDocker
+.\init.ps1 -InitEnv -LicenseXmlPath "C:\path\to\license.xml" -AdminPassword "DesiredAdminPassword" -Edge_Token "<<YOUR_EDGE_TOKEN>>" -EdgeNoDocker
 ```
 
 Running with the `-EdgeNoDocker` switch, will setup configuration files for each of the heads included in this repository. You can then manually run each of them using either NPM or DotNet.
@@ -149,4 +149,4 @@ Running with the `-EdgeNoDocker` switch, will setup configuration files for each
 After completing the init setup above you will be able to run the MVP Site either directly from within Visual Studio, or by using the DotNet CLI.
 
 - To run from within Visual Studio, open the `src\XmCloudIntroduction.sln`, ensure that the `Mvp.Project.MvpSite.Rendering` project is set as your StartUp Project, then hit F5.
-- To run from the DotNet CLI, open a new terminal window and navigate to the `src\Project\MvpSite\rendering` folder, then run `dotnet run`
+- To run from the DotNet CLI, open a new terminal window and navigate to the `src\Project\MvpSite\rendering` folder, then run `dotnet restore && dotnet run`

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Once you have initialized the repository with your Edge Token, use the `up.ps1` 
 
 ## 💻+🌏 Running in Edge Development Mode without Docker
 
-### Initialize your repository for Edge Development Mode with Docker
+### Initialize your repository for Edge Development Mode without Docker
 First initialize your repo using the `.init/ps1` script, you will need to pass in the `-Edge_Token` & `-EdgeNoDocker` parameters to ensure that the repository is correct initialised.
 
 ```ps1

--- a/README.md
+++ b/README.md
@@ -149,4 +149,13 @@ Running with the `-EdgeNoDocker` switch, will setup configuration files for each
 After completing the init setup above you will be able to run the MVP Site either directly from within Visual Studio, or by using the DotNet CLI.
 
 - To run from within Visual Studio, open the `src\XmCloudIntroduction.sln`, ensure that the `Mvp.Project.MvpSite.Rendering` project is set as your StartUp Project, then hit F5.
+  - The site should then be started loaded in the browser automatically
 - To run from the DotNet CLI, open a new terminal window and navigate to the `src\Project\MvpSite\rendering` folder, then run `dotnet restore && dotnet run`
+  - You can then access the site at `https://localhost:5001` or `http://localhost:5000`
+
+### Running the SUGCON Sites
+
+After completing the init setup above you will be able to run the SUGCON Sites directly using the NPM CLI, they are all built using SXA Headless so the process is the same for each of them.
+
+- Open a new terminal window and navigate to the `src\Project\Sugcon\<<SUGCON_SITE>>` folder, then run `npm i && npm run start:connected`
+  - You can then access the site at `http://localhost:3000`

--- a/init.ps1
+++ b/init.ps1
@@ -98,34 +98,34 @@ $SUGCON_INDIA_HOST = "sugconindia.$Host_Suffix"
 ##################################
 # Configure TLS/HTTPS certificates
 ##################################
-# Push-Location docker\traefik\certs
-# try {
-#     $mkcert = ".\mkcert.exe"
-#     if ($null -ne (Get-Command mkcert.exe -ErrorAction SilentlyContinue)) {
-#         # mkcert installed in PATH
-#         $mkcert = "mkcert"
-#     } elseif (-not (Test-Path $mkcert)) {
-#         Write-Host "Downloading and installing mkcert certificate tool..." -ForegroundColor Green
-#         Invoke-WebRequest "https://github.com/FiloSottile/mkcert/releases/download/v1.4.1/mkcert-v1.4.1-windows-amd64.exe" -UseBasicParsing -OutFile mkcert.exe
-#         if ((Get-FileHash mkcert.exe).Hash -ne "1BE92F598145F61CA67DD9F5C687DFEC17953548D013715FF54067B34D7C3246") {
-#             Remove-Item mkcert.exe -Force
-#             throw "Invalid mkcert.exe file"
-#         }
-#     }
-#     Write-Host "Generating Traefik TLS certificate." -ForegroundColor Green
-#     & $mkcert -install
-#     & $mkcert "*.$Host_Suffix"
-#     & $mkcert $Host_Suffix
+Push-Location docker\traefik\certs
+try {
+    $mkcert = ".\mkcert.exe"
+    if ($null -ne (Get-Command mkcert.exe -ErrorAction SilentlyContinue)) {
+        # mkcert installed in PATH
+        $mkcert = "mkcert"
+    } elseif (-not (Test-Path $mkcert)) {
+        Write-Host "Downloading and installing mkcert certificate tool..." -ForegroundColor Green
+        Invoke-WebRequest "https://github.com/FiloSottile/mkcert/releases/download/v1.4.1/mkcert-v1.4.1-windows-amd64.exe" -UseBasicParsing -OutFile mkcert.exe
+        if ((Get-FileHash mkcert.exe).Hash -ne "1BE92F598145F61CA67DD9F5C687DFEC17953548D013715FF54067B34D7C3246") {
+            Remove-Item mkcert.exe -Force
+            throw "Invalid mkcert.exe file"
+        }
+    }
+    Write-Host "Generating Traefik TLS certificate." -ForegroundColor Green
+    & $mkcert -install
+    & $mkcert "*.$Host_Suffix"
+    & $mkcert $Host_Suffix
 
-#     # stash CAROOT path for messaging at the end of the script
-#     $caRoot = "$(& $mkcert -CAROOT)\rootCA.pem"
-# }
-# catch {
-#     Write-Error "An error occurred while attempting to generate TLS certificate: $_"
-# }
-# finally {
-#     Pop-Location
-# }
+    # stash CAROOT path for messaging at the end of the script
+    $caRoot = "$(& $mkcert -CAROOT)\rootCA.pem"
+}
+catch {
+    Write-Error "An error occurred while attempting to generate TLS certificate: $_"
+}
+finally {
+    Pop-Location
+}
 
 ################################
 # Add Windows hosts file entries
@@ -258,4 +258,3 @@ catch {
 finally {
     Pop-Location
 }
-

--- a/init.ps1
+++ b/init.ps1
@@ -152,7 +152,7 @@ FETCH_WITH="GraphQL"
 
     Write-Host
     Write-Host ("#"*75) -ForegroundColor Cyan
-    Write-Host "Configuration Edge Mode without Docker complete" -ForegroundColor Cyan
+    Write-Host "Configuring Edge Mode without Docker complete" -ForegroundColor Cyan
     Write-Host "You can now run the different sites directly, please see the README for further details." -ForegroundColor Cyan
     Write-Host ("#"*75) -ForegroundColor Cyan
     exit 0
@@ -254,14 +254,6 @@ Add-HostsEntry $MVP_Host
 Add-HostsEntry $SUGCON_EU_HOST
 Add-HostsEntry $SUGCON_ANZ_HOST
 Add-HostsEntry $SUGCON_INDIA_HOST
-
-
-
-
-
-
-
-
 
 ##########################
 # Show Certificate Details

--- a/init.ps1
+++ b/init.ps1
@@ -97,7 +97,6 @@ Set-EnvFileVariable "JSS_EDITING_SECRET" -Value $jssEditingSecret
 ###############################
 if ($InitEnv) {
 	Write-Host "Populating .env file." -ForegroundColor Green
-	Set-EnvFileVariable "HOST_LICENSE_FOLDER" -Value $LicenseXmlPath
 	Set-EnvFileVariable "REPORTING_API_KEY" -Value (Get-SitecoreRandomString 128 -DisallowSpecial)
 	Set-EnvFileVariable "TELERIK_ENCRYPTION_KEY" -Value (Get-SitecoreRandomString 128 -DisallowSpecial)
 	Set-EnvFileVariable "MEDIA_REQUEST_PROTECTION_SHARED_SECRET" -Value (Get-SitecoreRandomString 64 -DisallowSpecial)
@@ -202,6 +201,7 @@ if (-not (Test-Path $LicenseXmlPath)) {
 }
 # We actually want the folder that it's in for mounting
 $LicenseXmlPath = (Get-Item $LicenseXmlPath).Directory.FullName
+Set-EnvFileVariable "HOST_LICENSE_FOLDER" -Value $LicenseXmlPath
 
 ###########################
 # Setup site host variables

--- a/init.ps1
+++ b/init.ps1
@@ -227,15 +227,28 @@ if ($EdgeNoDocker) {
     $appSettings.MvpSelectionsApiClient.BaseAddress = $env:MVP_SELECTIONS_API
     $appSettings | ConvertTo-Json | Out-File "src/Project/MvpSite/rendering/appsettings.Development.json"
     Write-Host "Finsihed Configuring MVP Head"
+
+    Write-Host "Creating .env for SUGCON Sites"
+    $sugconEnvContents = 
+@"
+SITECORE_API_HOST=${env:EXPERIENCE_EDGE_URL}
+SITECORE_API_KEY=${env:EXPERIENCE_EDGE_TOKEN}
+GRAPH_QL_ENDPOINT=${env:GRAPH_QL_ENDPOINT}
+FETCH_WITH="GraphQL"
+"@
+
+    Write-Host "Writing .env files for SUGCON Heads"
+    $sugconEnvContents | Out-File "src/Project/Sugcon/SugconAnzSxa/.env"
+    $sugconEnvContents | Out-File "src/Project/Sugcon/SugconEuSxa/.env"
+    $sugconEnvContents | Out-File "src/Project/Sugcon/SugconIndiaSxa/.env"
 }
 else {
-    Write-Host "Removing files used to configure Edge Mode without Docker" -ForegroundColor Green
-    
-    Write-Host "Configuring MVP Head"
+    Write-Host "Cleaning any files used to run Edge Mode without Docker" -ForegroundColor Green
     git restore 'src/Project/MvpSite/rendering/appsettings.Development.json'
-    Write-Host "Finsihed Configuring MVP Head"
+    if(Test-Path './src/Project/Sugcon/SugconAnzSxa/.env') { Remove-Item -Path './src/Project/Sugcon/SugconAnzSxa/.env' -Force }
+    if(Test-Path './src/Project/Sugcon/SugconEuSxa/.env') { Remove-Item -Path './src/Project/Sugcon/SugconEuSxa/.env' -Force }
+    if(Test-Path './src/Project/Sugcon/SugconIndiaSxa/.env') { Remove-Item -Path './src/Project/Sugcon/SugconIndiaSxa/.env' -Force }
 }
-
 
 ##########################
 # Show Certificate Details

--- a/init.ps1
+++ b/init.ps1
@@ -3,9 +3,9 @@
 Param (
 	[Parameter(HelpMessage = "Enables initialization of values in the .env file, which may be placed in source control.")]
     [switch]$InitEnv,
-    [Parameter(Mandatory = $true, HelpMessage = "The path to a valid Sitecore license.xml file.")]
+    [Parameter(HelpMessage = "The path to a valid Sitecore license.xml file.")]
     [string]$LicenseXmlPath,
-    [Parameter(Mandatory = $true, HelpMessage = "Sets the sitecore\\admin password for this environment via environment variable.")]
+    [Parameter(HelpMessage = "Sets the sitecore\\admin password for this environment via environment variable.")]
     [String]$AdminPassword,
     [Parameter(HelpMessage = "The Edge token used when running in Edge Mode.")]
     [string]$Edge_Token,
@@ -36,10 +36,136 @@ Param (
     [Parameter(HelpMessage = "SUGCON INDIA CPD Point of Sale.")]
     [string]$SUCGON_INDIA_CDP_POINTOFSALE,
     [Parameter(HelpMessage = "Switch to setup the heads to run against edge without docker.")]
-    [switch]$EdgeNoDocker
+    [switch]$Edge_NoDocker
 )
 
 $ErrorActionPreference = "Stop";
+
+##################
+# Create .env file
+##################
+Write-Host "Creating .env file." -ForegroundColor Green
+Copy-Item ".\.env.template" ".\.env" -Force
+
+###############################
+# Generate scjssconfig
+###############################
+$xmCloudBuild = Get-Content "xmcloud.build.json" | ConvertFrom-Json
+$scjssconfig = @{
+    sitecore= @{
+        deploySecret = $xmCloudBuild.renderingHosts.'sugconanz'.jssDeploymentSecret
+        deployUrl = "https://xmcloudcm.localhost/sitecore/api/jss/import"
+      }
+    }
+
+ConvertTo-Json -InputObject $scjssconfig | Out-File -FilePath "src\project\Sugcon\SugconAnzSxa\scjssconfig.json"
+ConvertTo-Json -InputObject $scjssconfig | Out-File -FilePath "src\project\Sugcon\SugconEuSxa\scjssconfig.json"
+ConvertTo-Json -InputObject $scjssconfig | Out-File -FilePath "src\project\Sugcon\SugconIndiaSxa\scjssconfig.json"
+
+################################
+# Generate JSS_EDITING_SECRET
+################################
+$jssEditingSecret = Get-SitecoreRandomString 64 -DisallowSpecial
+Set-EnvFileVariable "JSS_EDITING_SECRET" -Value $jssEditingSecret
+
+###############################
+# Populate the environment file
+###############################
+if ($InitEnv) {
+	Write-Host "Populating .env file." -ForegroundColor Green
+	Set-EnvFileVariable "HOST_LICENSE_FOLDER" -Value $LicenseXmlPath
+	Set-EnvFileVariable "CM_HOST" -Value $CM_Host
+	Set-EnvFileVariable "MVP_RENDERING_HOST" -Value $MVP_Host
+	Set-EnvFileVariable "REPORTING_API_KEY" -Value (Get-SitecoreRandomString 128 -DisallowSpecial)
+	Set-EnvFileVariable "TELERIK_ENCRYPTION_KEY" -Value (Get-SitecoreRandomString 128 -DisallowSpecial)
+	Set-EnvFileVariable "MEDIA_REQUEST_PROTECTION_SHARED_SECRET" -Value (Get-SitecoreRandomString 64 -DisallowSpecial)
+	Set-EnvFileVariable "SQL_SA_PASSWORD" -Value (Get-SitecoreRandomString 19 -DisallowSpecial -EnforceComplexity)
+    Set-EnvFileVariable "SQL_SERVER" -Value "mssql"
+    Set-EnvFileVariable "SQL_SA_LOGIN" -Value "sa"
+	Set-EnvFileVariable "SITECORE_ADMIN_PASSWORD" -Value $AdminPassword
+	Set-EnvFileVariable "EXPERIENCE_EDGE_TOKEN" -Value $Edge_Token
+	Set-EnvFileVariable "JSS_EDITING_SECRET" -Value (Get-SitecoreRandomString 64 -DisallowSpecial)
+	Set-EnvFileVariable "OKTA_DOMAIN" -Value $OKTA_Domain
+	Set-EnvFileVariable "OKTA_CLIENT_ID" -Value $OKTA_Client_Id
+	Set-EnvFileVariable "OKTA_CLIENT_SECRET" -Value $OKTA_Client_Secret
+    Set-EnvFileVariable "MVP_SELECTIONS_API" -Value $MVP_Selections_API
+    Set-EnvFileVariable "SUCGON_ANZ_CDP_CLIENT_KEY" -Value $SUCGON_ANZ_CDP_CLIENT_KEY
+    Set-EnvFileVariable "SUCGON_ANZ_CDP_TARGET_URL" -Value $SUCGON_ANZ_CDP_TARGET_URL
+    Set-EnvFileVariable "SUCGON_ANZ_CDP_POINTOFSALE" -Value $SUCGON_ANZ_CDP_POINTOFSALE
+    Set-EnvFileVariable "SUCGON_EU_CDP_CLIENT_KEY" -Value $SUCGON_EU_CDP_CLIENT_KEY
+    Set-EnvFileVariable "SUCGON_EU_CDP_TARGET_URL" -Value $SUCGON_EU_CDP_TARGET_URL
+    Set-EnvFileVariable "SUCGON_EU_CDP_POINTOFSALE" -Value $SUCGON_EU_CDP_POINTOFSALE
+    Set-EnvFileVariable "SUCGON_INDIA_CDP_CLIENT_KEY" -Value $SUCGON_INDIA_CDP_CLIENT_KEY
+    Set-EnvFileVariable "SUCGON_INDIA_CDP_TARGET_URL" -Value $SUCGON_INDIA_CDP_TARGET_URL
+    Set-EnvFileVariable "SUCGON_INDIA_CDP_POINTOFSALE" -Value $SUCGON_INDIA_CDP_POINTOFSALE
+}
+Write-Host "Finished populating .env file." -ForegroundColor Green
+
+##################################
+# Configure/Reset EdgeNoDockerMode
+##################################
+if ($Edge_NoDocker) {
+
+    # Ensure Edge token is passed in when attempting to setup Edge Mode without Docker
+    if($Edge_Token -eq "")
+    {
+        Write-Error "Edge Token is required when running in Edge Mode without Docker"
+        exit -1
+    }
+
+    Write-Host "Configuring heads to run in Edge Mode without Docker" -ForegroundColor Green
+
+    # Read .env into PS runtime for each access
+    get-content .env | ForEach-Object {
+        if(-Not $_.StartsWith("#") -and -Not $_ -eq "") { 
+            $splitChar = $_.IndexOf('=')
+            $name = $_.Substring(0, $splitChar)
+            $value = $_.Substring($splitChar + 1)
+            set-content env:\$name $value
+        }
+    } 
+    
+    Write-Host "Configuring MVP Head"
+    $appSettings = Get-Content 'src/Project/MvpSite/rendering/appsettings.Development.json' | ConvertFrom-Json
+    $appSettings.Sitecore.InstanceUri = $env:EXPERIENCE_EDGE_URL
+    $appSettings.Sitecore.LayoutServicePath = "/api/graphql/v1"
+    $appSettings.Sitecore.ExperienceEdgeToken = $env:EXPERIENCE_EDGE_TOKEN
+    $appSettings.Okta.OktaDomain = $env:OKTA_DOMAIN
+    $appSettings.Okta.ClientId = $env:OKTA_CLIENT_ID
+    $appSettings.Okta.ClientSecret = $env:OKTA_CLIENT_SECRET
+    $appSettings.Okta.AuthorizationServerId = $env:OKTA_AUTH_SERVER_ID
+    $appSettings.MvpSelectionsApiClient.BaseAddress = $env:MVP_SELECTIONS_API
+    $appSettings | ConvertTo-Json | Out-File "src/Project/MvpSite/rendering/appsettings.Development.json"
+    Write-Host "Finsihed Configuring MVP Head"
+
+    Write-Host "Creating .env for SUGCON Sites"
+    $sugconEnvContents = 
+@"
+SITECORE_API_HOST=${env:EXPERIENCE_EDGE_URL}
+SITECORE_API_KEY=${env:EXPERIENCE_EDGE_TOKEN}
+GRAPH_QL_ENDPOINT=${env:GRAPH_QL_ENDPOINT}
+FETCH_WITH="GraphQL"
+"@
+
+    Write-Host "Writing .env files for SUGCON Heads"
+    $sugconEnvContents | Out-File "src/Project/Sugcon/SugconAnzSxa/.env"
+    $sugconEnvContents | Out-File "src/Project/Sugcon/SugconEuSxa/.env"
+    $sugconEnvContents | Out-File "src/Project/Sugcon/SugconIndiaSxa/.env"
+
+    Write-Host
+    Write-Host ("#"*75) -ForegroundColor Cyan
+    Write-Host "Configuration Edge Mode without Docker complete" -ForegroundColor Cyan
+    Write-Host "You can now run the different sites directly, please see the README for further details." -ForegroundColor Cyan
+    Write-Host ("#"*75) -ForegroundColor Cyan
+    exit 0
+}
+else {
+    Write-Host "Cleaning any files used to run Edge Mode without Docker" -ForegroundColor Green
+    git restore 'src/Project/MvpSite/rendering/appsettings.Development.json'
+    if(Test-Path './src/Project/Sugcon/SugconAnzSxa/.env') { Remove-Item -Path './src/Project/Sugcon/SugconAnzSxa/.env' -Force }
+    if(Test-Path './src/Project/Sugcon/SugconEuSxa/.env') { Remove-Item -Path './src/Project/Sugcon/SugconEuSxa/.env' -Force }
+    if(Test-Path './src/Project/Sugcon/SugconIndiaSxa/.env') { Remove-Item -Path './src/Project/Sugcon/SugconIndiaSxa/.env' -Force }
+}
 
 ###############
 # License Check
@@ -53,12 +179,6 @@ if (-not (Test-Path $LicenseXmlPath)) {
 }
 # We actually want the folder that it's in for mounting
 $LicenseXmlPath = (Get-Item $LicenseXmlPath).Directory.FullName
-
-##################
-# Create .env file
-##################
-Write-Host "Creating .env file." -ForegroundColor Green
-Copy-Item ".\.env.template" ".\.env" -Force
 
 ################################################
 # Retrieve and import SitecoreDockerTools module
@@ -137,118 +257,13 @@ Add-HostsEntry $SUGCON_EU_HOST
 Add-HostsEntry $SUGCON_ANZ_HOST
 Add-HostsEntry $SUGCON_INDIA_HOST
 
-###############################
-# Generate scjssconfig
-###############################
-$xmCloudBuild = Get-Content "xmcloud.build.json" | ConvertFrom-Json
-$scjssconfig = @{
-    sitecore= @{
-        deploySecret = $xmCloudBuild.renderingHosts.'sugconanz'.jssDeploymentSecret
-        deployUrl = "https://xmcloudcm.localhost/sitecore/api/jss/import"
-      }
-    }
 
-ConvertTo-Json -InputObject $scjssconfig | Out-File -FilePath "src\project\Sugcon\SugconAnzSxa\scjssconfig.json"
-ConvertTo-Json -InputObject $scjssconfig | Out-File -FilePath "src\project\Sugcon\SugconEuSxa\scjssconfig.json"
-ConvertTo-Json -InputObject $scjssconfig | Out-File -FilePath "src\project\Sugcon\SugconIndiaSxa\scjssconfig.json"
 
-################################
-# Generate JSS_EDITING_SECRET
-################################
-$jssEditingSecret = Get-SitecoreRandomString 64 -DisallowSpecial
-Set-EnvFileVariable "JSS_EDITING_SECRET" -Value $jssEditingSecret
 
-###############################
-# Populate the environment file
-###############################
-if ($InitEnv) {
-	Write-Host "Populating .env file." -ForegroundColor Green
-	Set-EnvFileVariable "HOST_LICENSE_FOLDER" -Value $LicenseXmlPath
-	Set-EnvFileVariable "CM_HOST" -Value $CM_Host
-	Set-EnvFileVariable "MVP_RENDERING_HOST" -Value $MVP_Host
-	Set-EnvFileVariable "REPORTING_API_KEY" -Value (Get-SitecoreRandomString 128 -DisallowSpecial)
-	Set-EnvFileVariable "TELERIK_ENCRYPTION_KEY" -Value (Get-SitecoreRandomString 128 -DisallowSpecial)
-	Set-EnvFileVariable "MEDIA_REQUEST_PROTECTION_SHARED_SECRET" -Value (Get-SitecoreRandomString 64 -DisallowSpecial)
-	Set-EnvFileVariable "SQL_SA_PASSWORD" -Value (Get-SitecoreRandomString 19 -DisallowSpecial -EnforceComplexity)
-    Set-EnvFileVariable "SQL_SERVER" -Value "mssql"
-    Set-EnvFileVariable "SQL_SA_LOGIN" -Value "sa"
-	Set-EnvFileVariable "SITECORE_ADMIN_PASSWORD" -Value $AdminPassword
-	Set-EnvFileVariable "EXPERIENCE_EDGE_TOKEN" -Value $Edge_Token
-	Set-EnvFileVariable "JSS_EDITING_SECRET" -Value (Get-SitecoreRandomString 64 -DisallowSpecial)
-	Set-EnvFileVariable "OKTA_DOMAIN" -Value $OKTA_Domain
-	Set-EnvFileVariable "OKTA_CLIENT_ID" -Value $OKTA_Client_Id
-	Set-EnvFileVariable "OKTA_CLIENT_SECRET" -Value $OKTA_Client_Secret
-    Set-EnvFileVariable "MVP_SELECTIONS_API" -Value $MVP_Selections_API
-    Set-EnvFileVariable "SUCGON_ANZ_CDP_CLIENT_KEY" -Value $SUCGON_ANZ_CDP_CLIENT_KEY
-    Set-EnvFileVariable "SUCGON_ANZ_CDP_TARGET_URL" -Value $SUCGON_ANZ_CDP_TARGET_URL
-    Set-EnvFileVariable "SUCGON_ANZ_CDP_POINTOFSALE" -Value $SUCGON_ANZ_CDP_POINTOFSALE
-    Set-EnvFileVariable "SUCGON_EU_CDP_CLIENT_KEY" -Value $SUCGON_EU_CDP_CLIENT_KEY
-    Set-EnvFileVariable "SUCGON_EU_CDP_TARGET_URL" -Value $SUCGON_EU_CDP_TARGET_URL
-    Set-EnvFileVariable "SUCGON_EU_CDP_POINTOFSALE" -Value $SUCGON_EU_CDP_POINTOFSALE
-    Set-EnvFileVariable "SUCGON_INDIA_CDP_CLIENT_KEY" -Value $SUCGON_INDIA_CDP_CLIENT_KEY
-    Set-EnvFileVariable "SUCGON_INDIA_CDP_TARGET_URL" -Value $SUCGON_INDIA_CDP_TARGET_URL
-    Set-EnvFileVariable "SUCGON_INDIA_CDP_POINTOFSALE" -Value $SUCGON_INDIA_CDP_POINTOFSALE
-}
-Write-Host "Finished populating .env file." -ForegroundColor Green
 
-##################################
-# Configure/Reset EdgeNoDockerMode
-##################################
-if ($EdgeNoDocker) {
 
-    # Ensure Edge token is passed in when attempting to setup Edge Mode without Docker
-    if($Edge_Token -eq "")
-    {
-        Write-Error "Edge Token is required when running in Edge Mode without Docker"
-        exit -1
-    }
 
-    Write-Host "Configuring heads to run in Edge Mode without Docker" -ForegroundColor Green
 
-    # Read .env into PS runtime for each access
-    get-content .env | ForEach-Object {
-        if(-Not $_.StartsWith("#") -and -Not $_ -eq "") { 
-            $splitChar = $_.IndexOf('=')
-            $name = $_.Substring(0, $splitChar)
-            $value = $_.Substring($splitChar + 1)
-            set-content env:\$name $value
-        }
-    } 
-    
-    Write-Host "Configuring MVP Head"
-    $appSettings = Get-Content 'src/Project/MvpSite/rendering/appsettings.Development.json' | ConvertFrom-Json
-    $appSettings.Sitecore.InstanceUri = $env:EXPERIENCE_EDGE_URL
-    $appSettings.Sitecore.LayoutServicePath = "/api/graphql/v1"
-    $appSettings.Sitecore.ExperienceEdgeToken = $env:EXPERIENCE_EDGE_TOKEN
-    $appSettings.Okta.OktaDomain = $env:OKTA_DOMAIN
-    $appSettings.Okta.ClientId = $env:OKTA_CLIENT_ID
-    $appSettings.Okta.ClientSecret = $env:OKTA_CLIENT_SECRET
-    $appSettings.Okta.AuthorizationServerId = $env:OKTA_AUTH_SERVER_ID
-    $appSettings.MvpSelectionsApiClient.BaseAddress = $env:MVP_SELECTIONS_API
-    $appSettings | ConvertTo-Json | Out-File "src/Project/MvpSite/rendering/appsettings.Development.json"
-    Write-Host "Finsihed Configuring MVP Head"
-
-    Write-Host "Creating .env for SUGCON Sites"
-    $sugconEnvContents = 
-@"
-SITECORE_API_HOST=${env:EXPERIENCE_EDGE_URL}
-SITECORE_API_KEY=${env:EXPERIENCE_EDGE_TOKEN}
-GRAPH_QL_ENDPOINT=${env:GRAPH_QL_ENDPOINT}
-FETCH_WITH="GraphQL"
-"@
-
-    Write-Host "Writing .env files for SUGCON Heads"
-    $sugconEnvContents | Out-File "src/Project/Sugcon/SugconAnzSxa/.env"
-    $sugconEnvContents | Out-File "src/Project/Sugcon/SugconEuSxa/.env"
-    $sugconEnvContents | Out-File "src/Project/Sugcon/SugconIndiaSxa/.env"
-}
-else {
-    Write-Host "Cleaning any files used to run Edge Mode without Docker" -ForegroundColor Green
-    git restore 'src/Project/MvpSite/rendering/appsettings.Development.json'
-    if(Test-Path './src/Project/Sugcon/SugconAnzSxa/.env') { Remove-Item -Path './src/Project/Sugcon/SugconAnzSxa/.env' -Force }
-    if(Test-Path './src/Project/Sugcon/SugconEuSxa/.env') { Remove-Item -Path './src/Project/Sugcon/SugconEuSxa/.env' -Force }
-    if(Test-Path './src/Project/Sugcon/SugconIndiaSxa/.env') { Remove-Item -Path './src/Project/Sugcon/SugconIndiaSxa/.env' -Force }
-}
 
 ##########################
 # Show Certificate Details

--- a/init.ps1
+++ b/init.ps1
@@ -74,8 +74,6 @@ Set-EnvFileVariable "JSS_EDITING_SECRET" -Value $jssEditingSecret
 if ($InitEnv) {
 	Write-Host "Populating .env file." -ForegroundColor Green
 	Set-EnvFileVariable "HOST_LICENSE_FOLDER" -Value $LicenseXmlPath
-	Set-EnvFileVariable "CM_HOST" -Value $CM_Host
-	Set-EnvFileVariable "MVP_RENDERING_HOST" -Value $MVP_Host
 	Set-EnvFileVariable "REPORTING_API_KEY" -Value (Get-SitecoreRandomString 128 -DisallowSpecial)
 	Set-EnvFileVariable "TELERIK_ENCRYPTION_KEY" -Value (Get-SitecoreRandomString 128 -DisallowSpecial)
 	Set-EnvFileVariable "MEDIA_REQUEST_PROTECTION_SHARED_SECRET" -Value (Get-SitecoreRandomString 64 -DisallowSpecial)

--- a/src/Project/MvpSite/rendering/appsettings.Development.json
+++ b/src/Project/MvpSite/rendering/appsettings.Development.json
@@ -14,5 +14,14 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Okta" : {
+    "OktaDomain": "<<Add Okta domain>>",
+    "ClientId": "<<Add Okta client id>>",
+    "ClientSecret": "<<Add Okta client secret>>",
+    "AuthorizationServerId": "<<Add Okta auth server>>"
+  },
+  "MvpSelectionsApiClient": {
+    "BaseAddress": "<<Add MVP Selection API URL>>"
+  }
 }


### PR DESCRIPTION
This PR automates the ability to configure this repository to run 'Edge Development mode with No Docker'. It adds a new param to `init.ps1` which will configure the heads, they can the be manually run directly on the host machine.

The README has been updated to include steps required.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.

Closes #178 