### PR TITLE
Update init.ps1

### DIFF
--- a/init.ps1
+++ b/init.ps1
@@ -40,7 +40,7 @@ Param (
     [Parameter(HelpMessage = "SUGCON NA CPD Target URL.")]
     [string]$SUCGON_NA_CDP_TARGET_URL,
     [Parameter(HelpMessage = "SUGCON NA CPD Point of Sale.")]
-    [string]$SUCGON_NA_CDP_POINTOFSALE
+    [string]$SUCGON_NA_CDP_POINTOFSALE,
     [Parameter(HelpMessage = "Switch to setup the heads to run against edge without docker.")]
     [switch]$Edge_NoDocker
 )


### PR DESCRIPTION
Fix ParserError caused by missing comma in init.ps1
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
When running the `.\init.ps1 -InitEnv -LicenseXmlPath "C:\path\to\license.xml" -AdminPassword "DesiredAdminPassword"`, a ParserError occurs on line number 43, preventing users from successfully executing the init.ps1 command. The error is caused by the absence of a comma (,) in line number 43.

**Error:**
```
ParserError: D:\Playground\XM-Cloud-Introduction\init.ps1:43
Line |
  43 |      [string]$SUCGON_NA_CDP_POINTOFSALE
     |                                        ~
     | Missing ')' in function parameter list.
```

<!--- Why is this change required? What problem does it solve? -->
This pull request addresses the issue by adding the missing comma on line number 43, allowing users to run the init.ps1 command without encountering the ParserError.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

- After identifying the ParserError caused by the missing comma in init.ps1, I made the necessary code changes to add the comma at line number 43
- To test the changes, I set up my local environment using Docker
- With the fix in place, I executed the command `.\init.ps1 -InitEnv -LicenseXmlPath "C:\path\to\license.xml" -AdminPassword "DesiredAdminPassword"` in my local environment
- Upon running the command, I closely monitored the console output for any errors or exceptions. Additionally, I checked the application's behavior to verify that the initialization process executed as expected

<!--- Include details of your testing environment, and the tests you ran to -->
**Before the fix:**
![image](https://github.com/Sitecore/XM-Cloud-Introduction/assets/17798071/b96c9c34-bb5c-415e-abcb-d0ccfc652a58)

**After the fix:**
![image](https://github.com/Sitecore/XM-Cloud-Introduction/assets/17798071/68e97b7b-3ff2-40d3-a1ed-2646ebd874fd)

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.