### PR TITLE
Update NewEdgeToken script to initialize cli settings

### DIFF
--- a/New-EdgeToken.ps1
+++ b/New-EdgeToken.ps1
@@ -11,6 +11,8 @@ Write-Host "Restoring Sitecore CLI..." -ForegroundColor Green
 dotnet tool restore
 Write-Host "Installing Sitecore CLI Plugins..."
 dotnet sitecore --help | Out-Null
+Write-Host "Logging into Sitecore..." -ForegroundColor Green
+dotnet sitecore cloud login
 
 $XmCloudVersion = (get-content sitecore.json | ConvertFrom-Json).plugins -match 'Sitecore.DevEx.Extensibility.XMCloud' 
 if ($XmCloudVersion -eq '' -or $LASTEXITCODE -ne 0) {

--- a/New-EdgeToken.ps1
+++ b/New-EdgeToken.ps1
@@ -7,6 +7,11 @@ param (
 
 $ErrorActionPreference = "Stop"
 
+Write-Host "Restoring Sitecore CLI..." -ForegroundColor Green
+dotnet tool restore
+Write-Host "Installing Sitecore CLI Plugins..."
+dotnet sitecore --help | Out-Null
+
 $XmCloudVersion = (get-content sitecore.json | ConvertFrom-Json).plugins -match 'Sitecore.DevEx.Extensibility.XMCloud' 
 if ($XmCloudVersion -eq '' -or $LASTEXITCODE -ne 0) {
     Write-Error "Unable to find version of XM Cloud Plugin"


### PR DESCRIPTION
The `NewEdgeToken.ps1` script currently assumes you've ran the repo already and initialised the CLI. This change forces initialisation of the CLI so that it can be run directly without having to run the repo first.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.