### PR TITLE
Remove extra forward slash in URL

### DIFF
--- a/New-EdgeToken.ps1
+++ b/New-EdgeToken.ps1
@@ -32,7 +32,7 @@ $URL = @(
 
 $Response = Invoke-RestMethod ($URL -join '/') -Method 'GET' -Headers $Headers -Verbose
 $AccessToken = $Response.apiKey
-$EdgeUrl = "$($Response.edgeUrl)/api/graphql/ide"
+$EdgeUrl = "$($Response.edgeUrl)api/graphql/ide"
 Write-Host "Launching Edge GraphQL IDE"
 Write-Host "Add { ""X-GQL-Token"" : ""$AccessToken"" } to the HTTP HEADERS tab at the bottom-left of the screen to write queries against your content"
 Start-Process $EdgeUrl


### PR DESCRIPTION
The `New-EdgeToken.ps1` script was opening the GraphQL browser IDE with an extra forward slash (/) causing the URL to fail. `edgURL` from the `Response` object contains a trailing forward slash so I removed the one in our code. 

## Description / Motivation

Fix URL for automatically opening the browser based GraphQL IDE

## How Has This Been Tested?

Tested locally with `1C6WJAKXzE6MR09hYzdzSH` Environment Id. 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.