### PR TITLE
Header and nav style tweaks for SUGCON ANZ

### DIFF
--- a/src/Project/Sugcon/SugconAnzSxa/src/assets/app.scss
+++ b/src/Project/Sugcon/SugconAnzSxa/src/assets/app.scss
@@ -85,8 +85,7 @@ header {
     .navigation {
         margin-top: 50px;
     }
-    .richtext {
-        background-color: #666;
+    .richtext {        
         font-size: 0.8em;
         a {
             text-decoration: none;

--- a/src/Project/Sugcon/SugconAnzSxa/src/assets/app.scss
+++ b/src/Project/Sugcon/SugconAnzSxa/src/assets/app.scss
@@ -86,7 +86,7 @@ header {
         }
     }
     .navigation {
-        margin-top: 50px;
+        margin-top: 25px;        
     }
     .richtext {        
         font-size: 0.8em;

--- a/src/Project/Sugcon/SugconAnzSxa/src/assets/app.scss
+++ b/src/Project/Sugcon/SugconAnzSxa/src/assets/app.scss
@@ -79,8 +79,11 @@ header {
     display: grid;
     width: 100%;
     img {
-        width: 315px;
+        width: 250px;
         margin: 15px;
+        @media (min-width: 576px)  {
+            width: 315px;        
+        }
     }
     .navigation {
         margin-top: 50px;


### PR DESCRIPTION
## Description / Motivation
Adjusted app sass styles used in the header to address some issues identified when testing the rebranding on SUGCON ANZ site.  Specifically:

1. Remove explicit usage of the #666 background-color in .header .richtext allowing it to fall back to the class/bg colour used in the container (background-dark-grey / #707070)
2. Reduce the logo image width in a media query in css to avoid it clashing with on mobile screens below XS breakpoint
3. Vertically align the navbar options

## How Has This Been Tested?
Tested locally in Full local development mode with the SUGCON ANZ site running locally in connected mode.  The style changes should be contained to the SUGCON ANZ site.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.