### PR TITLE
Fixing casing of og:Image and og:Type on SUGCON sites to lowercase

### DIFF
--- a/src/Project/Sugcon/SugconAnzSxa/src/Layout.tsx
+++ b/src/Project/Sugcon/SugconAnzSxa/src/Layout.tsx
@@ -71,13 +71,13 @@ const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
         )}
 
         {fields?.OgImage?.value?.src ? (
-          <meta property="og:Image" content={`${fields?.OgImage?.value?.src}`} />
+          <meta property="og:image" content={`${fields?.OgImage?.value?.src}`} />
         ) : (
           ''
         )}
 
         {fields?.OgType?.value ? (
-          <meta property="og:Type" content={`${fields?.OgType?.value}`} />
+          <meta property="og:type" content={`${fields?.OgType?.value}`} />
         ) : (
           ''
         )}

--- a/src/Project/Sugcon/SugconAnzSxa/src/Layout.tsx
+++ b/src/Project/Sugcon/SugconAnzSxa/src/Layout.tsx
@@ -59,7 +59,7 @@ const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
         )}
         {/* Open Graph Tags */}
         {fields?.OgTitle?.value ? (
-          <meta property="og:title" content={`${fields?.OgTitle?.value}`} />
+          <meta name="title" property="og:title" content={`${fields?.OgTitle?.value}`} />
         ) : (
           ''
         )}
@@ -71,7 +71,7 @@ const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
         )}
 
         {fields?.OgImage?.value?.src ? (
-          <meta property="og:image" content={`${fields?.OgImage?.value?.src}`} />
+          <meta name="image" property="og:image" content={`${fields?.OgImage?.value?.src}`} />
         ) : (
           ''
         )}

--- a/src/Project/Sugcon/SugconEuSxa/src/Layout.tsx
+++ b/src/Project/Sugcon/SugconEuSxa/src/Layout.tsx
@@ -73,13 +73,13 @@ const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
         )}
 
         {fields?.OgImage?.value?.src ? (
-          <meta property="og:Image" content={`${fields?.OgImage?.value?.src}`} />
+          <meta property="og:image" content={`${fields?.OgImage?.value?.src}`} />
         ) : (
           ''
         )}
 
         {fields?.OgType?.value ? (
-          <meta property="og:Type" content={`${fields?.OgType?.value}`} />
+          <meta property="og:type" content={`${fields?.OgType?.value}`} />
         ) : (
           ''
         )}

--- a/src/Project/Sugcon/SugconEuSxa/src/Layout.tsx
+++ b/src/Project/Sugcon/SugconEuSxa/src/Layout.tsx
@@ -61,7 +61,7 @@ const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
         )}
         {/* Open Graph Tags */}
         {fields?.OgTitle?.value ? (
-          <meta property="og:title" content={`${fields?.OgTitle?.value}`} />
+          <meta name="title" property="og:title" content={`${fields?.OgTitle?.value}`} />
         ) : (
           ''
         )}
@@ -73,7 +73,7 @@ const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
         )}
 
         {fields?.OgImage?.value?.src ? (
-          <meta property="og:image" content={`${fields?.OgImage?.value?.src}`} />
+          <meta name="image" property="og:image" content={`${fields?.OgImage?.value?.src}`} />
         ) : (
           ''
         )}

--- a/src/Project/Sugcon/SugconIndiaSxa/src/Layout.tsx
+++ b/src/Project/Sugcon/SugconIndiaSxa/src/Layout.tsx
@@ -73,13 +73,13 @@ const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
         )}
 
         {fields?.OgImage?.value?.src ? (
-          <meta property="og:Image" content={`${fields?.OgImage?.value?.src}`} />
+          <meta property="og:image" content={`${fields?.OgImage?.value?.src}`} />
         ) : (
           ''
         )}
 
         {fields?.OgType?.value ? (
-          <meta property="og:Type" content={`${fields?.OgType?.value}`} />
+          <meta property="og:type" content={`${fields?.OgType?.value}`} />
         ) : (
           ''
         )}

--- a/src/Project/Sugcon/SugconIndiaSxa/src/Layout.tsx
+++ b/src/Project/Sugcon/SugconIndiaSxa/src/Layout.tsx
@@ -61,7 +61,7 @@ const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
         )}
         {/* Open Graph Tags */}
         {fields?.OgTitle?.value ? (
-          <meta property="og:title" content={`${fields?.OgTitle?.value}`} />
+          <meta name="title" property="og:title" content={`${fields?.OgTitle?.value}`} />
         ) : (
           ''
         )}
@@ -73,7 +73,7 @@ const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
         )}
 
         {fields?.OgImage?.value?.src ? (
-          <meta property="og:image" content={`${fields?.OgImage?.value?.src}`} />
+          <meta name="image" property="og:image" content={`${fields?.OgImage?.value?.src}`} />
         ) : (
           ''
         )}

--- a/src/Project/Sugcon/SugconNaSxa/src/Layout.tsx
+++ b/src/Project/Sugcon/SugconNaSxa/src/Layout.tsx
@@ -71,13 +71,13 @@ const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
         )}
 
         {fields?.OgImage?.value?.src ? (
-          <meta property="og:Image" content={`${fields?.OgImage?.value?.src}`} />
+          <meta property="og:image" content={`${fields?.OgImage?.value?.src}`} />
         ) : (
           ''
         )}
 
         {fields?.OgType?.value ? (
-          <meta property="og:Type" content={`${fields?.OgType?.value}`} />
+          <meta property="og:type" content={`${fields?.OgType?.value}`} />
         ) : (
           ''
         )}

--- a/src/Project/Sugcon/SugconNaSxa/src/Layout.tsx
+++ b/src/Project/Sugcon/SugconNaSxa/src/Layout.tsx
@@ -59,7 +59,7 @@ const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
         )}
         {/* Open Graph Tags */}
         {fields?.OgTitle?.value ? (
-          <meta property="og:title" content={`${fields?.OgTitle?.value}`} />
+          <meta name="title" property="og:title" content={`${fields?.OgTitle?.value}`} />
         ) : (
           ''
         )}
@@ -71,7 +71,7 @@ const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
         )}
 
         {fields?.OgImage?.value?.src ? (
-          <meta property="og:image" content={`${fields?.OgImage?.value?.src}`} />
+          <meta name="image" property="og:image" content={`${fields?.OgImage?.value?.src}`} />
         ) : (
           ''
         )}


### PR DESCRIPTION
Fixes #288 by lowercasing the open graph tags for Image and Type in the SUGCON sites. This will hopefully correct the Teams issues of loading images for SUGCON pages.

## How Has This Been Tested?
Tested on Vercel preview site and in Teams.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.