### PR TITLE
Add SITECORE_GraphQL_CORS environment variable

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -279,6 +279,7 @@ services:
       SITECORE_JSS_EDITING_SECRET: ${JSS_EDITING_SECRET}
       SITECORE_Pages_Client_Host: ${SITECORE_Pages_Client_Host}
       SITECORE_Pages_CORS_Allowed_Origins: ${SITECORE_Pages_CORS_Allowed_Origins}
+      SITECORE_GraphQL_CORS: ${SITECORE_GRAPHQL_CORS}
       ## SugconEu Rendering Host
       SUGCONEU_RENDERING_HOST_ENDPOINT_URI: "${SUGCON_EU_HOST_INTERNAL_URI}/api/editing/render"
       SUGCONEU_RENDERING_HOST_PUBLIC_URI: "https://${SUGCON_EU_HOST}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This fixes #316 

## Description / Motivation

Add SITECORE_GraphQL_CORS to the docker-compose-override.yml environment variables for the cm container.  This will allow Pages to connect to the local cm container.

## How Has This Been Tested?

I tested by updating the .env file to 
1. leave out the SITECORE_GraphQL_CORS
2. set the SITECORE_GraphQL_CORS to an empty value
3. set the SITECORE_GraphQL_CORS to an incorrect value
4. set the SITECORE_GraphQL_CORS to the correct value
5. 
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [] My change is a documentation change and there are NO other updates required.