### PR TITLE
Remove depends_on fields

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,4 @@
 services:
-
   nodejs:
     image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-nodejs:${VERSION:-latest}
     build:
@@ -42,7 +41,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:3000/api/healthz"]
       interval: 60s
       timeout: 30s
-  
+
   sugconanz:
     image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-sugcon-anz:${VERSION:-latest}
     build:
@@ -212,7 +211,7 @@ services:
       MVP_RENDERING_EDITING_HOST_URI: "http://mvp-rendering"
       Sitecore__InstanceUri: "http://cm"
       Sitecore__RenderingHostUri: "https://${MVP_RENDERING_HOST}"
-      Sitecore__EnableExperienceEditor: "true" 
+      Sitecore__EnableExperienceEditor: "true"
       Sitecore__JssEditingSecret: ${JSS_EDITING_SECRET}
       Okta__OktaDomain: ${OKTA_DOMAIN}
       Okta__ClientId: ${OKTA_CLIENT_ID}
@@ -226,19 +225,16 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.mvp-secure.entrypoints=websecure"
       - "traefik.http.routers.mvp-secure.rule=Host(`${MVP_RENDERING_HOST}`)"
-      - "traefik.http.routers.mvp-secure.tls=true"   
+      - "traefik.http.routers.mvp-secure.tls=true"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/healthz"]
       interval: 60s
       timeout: 30s
 
-
   # Mount the Traefik configuration and certs.
   traefik:
     volumes:
       - ./docker/traefik:C:/etc/traefik
-    depends_on:
-      - cm
 
   # Mount our SQL data folder and use our custom image with the Headless Services (JSS)
   # module data added. See Dockerfile for details.
@@ -267,8 +263,6 @@ services:
         PARENT_IMAGE: ${SITECORE_DOCKER_REGISTRY}sitecore-xmcloud-cm:${SITECORE_VERSION}
         SOLUTION_IMAGE: ${REGISTRY}${COMPOSE_PROJECT_NAME}-solution:${VERSION:-latest}
         TOOLS_IMAGE: ${TOOLS_IMAGE}
-    depends_on:
-      - solution
     volumes:
       - ${LOCAL_DEPLOY_PATH}\platform:C:\deploy
       - ${LOCAL_DATA_PATH}\cm:C:\inetpub\wwwroot\App_Data\logs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When starting the local docker environment, there is an error.  It is caused because both the docker-compose.yml and docker-compose-override.yml define the "depends_on" properties for the traefik and cm containers.

![image](https://github.com/Sitecore/XM-Cloud-Introduction/assets/21204526/6044fda5-4f8a-4c24-b7a9-5876bbd2c82a)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I removed the depends_on from the docker-compose-override.yml and the containers start correctly without error.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.