### PR TITLE
Changed XMC build to be triggered for Rendering Host changes

### DIFF
--- a/.github/workflows/CI-CD_XM_Cloud.yml
+++ b/.github/workflows/CI-CD_XM_Cloud.yml
@@ -10,6 +10,8 @@ on:
     - 'xmcloud.build.json'
     - 'src/**/platform/**'
     - 'src/**/items/**'
+    - 'src/Project/Sugcon2024/**'
+    - 'src/Project/Sugcon/**'
   pull_request:
     branches: [ main ]
     paths:
@@ -19,6 +21,8 @@ on:
     - 'xmcloud.build.json'
     - 'src/**/platform/**'
     - 'src/**/items/**'
+    - 'src/Project/Sugcon2024/**'
+    - 'src/Project/Sugcon/**'
 
 jobs:
 


### PR DESCRIPTION
Updated the CI-CD definition for XMC to also trigger on files changes for the SUGCON heads, as those changes need to be reflected in the Editing Hosts that XMC deploys

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.