### PR TITLE
Display Image at My Data

### DIFF
--- a/src/Feature/Selections/rendering/Models/Any/MyDataEditModel.cs
+++ b/src/Feature/Selections/rendering/Models/Any/MyDataEditModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Mvp.Selections.Domain;
@@ -39,6 +40,8 @@ namespace Mvp.Feature.Selections.Models.Any
         [Required]
         [FromForm(Name = $"{nameof(MyDataEditModel)}.{nameof(ImageType)}")]
         public ImageType ImageType { get; set; }
+
+        public Uri ImageUri { get; set; }
 
         public List<Consent> Consents { get; init; } = new ();
 

--- a/src/Feature/Selections/rendering/ViewComponents/Any/MyDataEditViewComponent.cs
+++ b/src/Feature/Selections/rendering/ViewComponents/Any/MyDataEditViewComponent.cs
@@ -12,14 +12,10 @@ using Sitecore.AspNet.RenderingEngine.Binding;
 namespace Mvp.Feature.Selections.ViewComponents.Any
 {
     [ViewComponent(Name = ViewComponentName)]
-    public class MyDataEditViewComponent : BaseViewComponent
+    public class MyDataEditViewComponent(IViewModelBinder modelBinder, MvpSelectionsApiClient client)
+        : BaseViewComponent(modelBinder, client)
     {
         public const string ViewComponentName = "AnyMyDataEdit";
-
-        public MyDataEditViewComponent(IViewModelBinder modelBinder, MvpSelectionsApiClient client)
-            : base(modelBinder, client)
-        {
-        }
 
         public override async Task<IViewComponentResult> InvokeAsync()
         {
@@ -52,6 +48,7 @@ namespace Mvp.Feature.Selections.ViewComponents.Any
                     model.Email = user.Email;
                     model.CountryId = user.Country?.Id ?? 0;
                     model.ImageType = user.ImageType;
+                    model.ImageUri = user.ImageUri;
                     ModelState.Clear();
                 }
                 else if (userResponse != null && userResponse.StatusCode != HttpStatusCode.OK)

--- a/src/Feature/Selections/rendering/Views/Shared/Components/AnyMyDataEdit/Default.cshtml
+++ b/src/Feature/Selections/rendering/Views/Shared/Components/AnyMyDataEdit/Default.cshtml
@@ -52,6 +52,9 @@
                 </select>
                 <span asp-validation-for="ImageType" class="text-danger"></span>
             </div>
+            <div class="form-group">
+                <img src="@(Model.ImageUri?.ToString() ?? "/images/mvp-base-user-grey.png")" />
+            </div>
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <button asp-for="SubmitLabel" type="submit" class="btn btn-primary"></button>
         </form>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation

<!--- Describe your changes in detail -->
This displays your image when editing your profile data

<!--- Why is this change required? What problem does it solve? -->
Users can't validate their image currently unless the Directory updates which is on a 1h cache. With this users can make their choice of Image Type more reliably.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Manual UI Test

<!--- Include details of your testing environment, and the tests you ran to -->
Local Machine

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.