### PR TITLE
Overwritten style of the link on the organizers list - a hidden icon …

### DIFF
--- a/src/Project/Sugcon/SugconEuSxa/src/assets/app.scss
+++ b/src/Project/Sugcon/SugconEuSxa/src/assets/app.scss
@@ -52,6 +52,10 @@ a[target='_blank']:after {
   content: '\1F5D7';
 }
 
+.organizers-container a[target='_blank']:after{
+  content: none;
+}
+
 /*
 Hides Sitecore Experience Editor markup,
 if you run the app in connected mode while the Sitecore cookies

--- a/src/Project/Sugcon/SugconEuSxa/src/components/Sugcon/OrganiserList.tsx
+++ b/src/Project/Sugcon/SugconEuSxa/src/components/Sugcon/OrganiserList.tsx
@@ -34,7 +34,7 @@ export const Default = (props: OrganiserListProps): JSX.Element => {
   console.log(props);
   if (props.fields) {
     return (
-      <div className="container component">
+      <div className="container component organizers-container">
         <div className="row">
           {props.fields?.Organisers?.length == 0 ? (
             <div>No Organisers</div>


### PR DESCRIPTION
Overwritten style of the link on the organizers list - a hidden icon that does not fit well to the content

## Description / Motivation

On the page https://europe.sugcon.events/Organisation we have a list of the organizers of the event. 
When the link to LinkedIn or Twitter has selected 'open in a new window' option, a general style adds an icon as content and it does not look good and does not bring any value.

![image](https://github.com/Sitecore/XM-Cloud-Introduction/assets/2719633/234edc57-f83e-4c49-a3b6-365826f955c3)

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Change adds a new class to HTML container displaying the data and instead of changing the general class I added a new more precise definition to change the behavior only of the elements from the list. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The change was tested locally - by checking if the icon is hidden after the changes. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.