### PR TITLE
Bumped images version, so all docker images default to LTSC2022

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -22,7 +22,7 @@ NODE_ENV=development
 # The ltsc2019-based images are used by default here. SAC images are also available.
 SITECORE_DOCKER_REGISTRY=scr.sitecore.com/xmcloud/
 SITECORE_NONPRODUCTION_DOCKER_REGISTRY=scr.sitecore.com/sxp/
-SITECORE_VERSION=1-ltsc2019
+SITECORE_VERSION=1-ltsc2022
 EXTERNAL_IMAGE_TAG_SUFFIX=10.2-ltsc2022
 
 # The sitecore\admin and SQL 'sa' account passwords for this environment are configurable here.
@@ -33,8 +33,8 @@ SQL_SA_PASSWORD=
 SQL_DATABASE_PREFIX=Sitecore
 
 # Other supporting images, including Sitecore modules and Docker tools
-TOOLS_IMAGE=scr.sitecore.com/tools/sitecore-docker-tools-assets:10.2.0-1809
-TRAEFIK_IMAGE=traefik:v2.5.3-windowsservercore-1809
+TOOLS_IMAGE=scr.sitecore.com/tools/sitecore-docker-tools-assets:10.3-ltsc2022
+TRAEFIK_IMAGE=traefik:v2.11.0-windowsservercore-ltsc2022
 SOLUTION_BUILD_IMAGE=mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022
 SOLUTION_BASE_IMAGE=mcr.microsoft.com/windows/nanoserver:ltsc2022
 NETCORE_BUILD_IMAGE=mcr.microsoft.com/dotnet/sdk:8.0-nanoserver-ltsc2022


### PR DESCRIPTION
All docker base images are now running against LTSC2022.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.