### PR TITLE
Update styles to fix unwanted space at certain screen sizes

### DIFF
--- a/src/Project/Sugcon2024/Sugcon/src/components/Basic Components/Hero.tsx
+++ b/src/Project/Sugcon2024/Sugcon/src/components/Basic Components/Hero.tsx
@@ -34,10 +34,12 @@ export const HeroHomepage = (props: HeroProps): JSX.Element => {
   return (
     <Flex
       direction={{ base: 'column', md: 'row' }}
-      alignItems="center"
+      alignItems="stretch"
       bg="#f0f0f0"
       maxHeight={{ base: 'auto', md: '400px' }}
       w="100%"
+      h={{ base: 'auto', md: '100vh' }}
+      overflow="hidden"
     >
       <Flex
         direction="column"
@@ -45,6 +47,7 @@ export const HeroHomepage = (props: HeroProps): JSX.Element => {
         p={5}
         flexGrow={1}
         minWidth="50%"
+        justifyContent="center"
       >
         <Box width="auto" alignSelf="end" maxWidth="620px" minWidth="360px">
           <Heading as="h2" fontSize="30px" fontWeight="bold" mb="33px">
@@ -67,14 +70,13 @@ export const HeroHomepage = (props: HeroProps): JSX.Element => {
           )}
         </Box>
       </Flex>
-      <Box minWidth={{ base: '100%', md: '50%' }} maxHeight="400px" h="100%" overflow="hidden">
+      <Box flexShrink={0} minWidth={{ base: '100%', md: '50%' }} h="full" overflow="hidden">
         {' '}
         <Image
           src={props.fields.Image?.value?.src}
           //alt={props.fields.Image?.value?.alt}
           width="full"
-          height="100%"
-          maxHeight="400px"
+          height="full"
           objectFit="cover"
         />
       </Box>

--- a/src/Project/Sugcon2024/Sugcon/src/stories/components/Basic Components/HomepageHero.stories.ts
+++ b/src/Project/Sugcon2024/Sugcon/src/stories/components/Basic Components/HomepageHero.stories.ts
@@ -36,7 +36,7 @@ export const Homepage: Story = {
       },
       Image: {
         value: {
-          src: 'https://picsum.photos/1200/800',
+          src: 'https://picsum.photos/1000/566',
         },
       },
     },


### PR DESCRIPTION
Updating the styles to ensure that the hero image fills all of the space and doesn't leave any gaps.

## Description / Motivation

We found some gaps in Storybook at certain screen sizes and needed to touch up the styles.

## How Has This Been Tested?

Locally with storybook at all screen sizes

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.