### PR TITLE
Enabling Web Experiences from Personalize

### DIFF
--- a/src/Project/Sugcon/SugconNaSxa/src/components/Sugcon/SugConCdpPageView.tsx
+++ b/src/Project/Sugcon/SugconNaSxa/src/components/Sugcon/SugConCdpPageView.tsx
@@ -35,11 +35,14 @@ const SugConCdpPageView = (): JSX.Element => {
     const engage = await init({
       clientKey: process.env.NEXT_PUBLIC_CDP_CLIENT_KEY || '',
       targetURL: process.env.NEXT_PUBLIC_CDP_TARGET_URL || '',
+      pointOfSale,
       // Replace with the top level cookie domain of the website that is being integrated e.g ".example.com" and not "www.example.com"
       cookieDomain:
         process.env.NODE_ENV === 'development' ? '' : window.location.host.replace(/^www\./, ''),
       // Cookie may be created in personalize middleware (server), but if not we should create it here
       forceServerCookieMode: false,
+      // Enable Personalize Web Experiences
+      webPersonalization: true,
     });
 
     let additionalData = {};


### PR DESCRIPTION
## Description / Motivation

Unfortunately, my ability to configure conditions for the SUGCON Europe presentation isn't going well.  Adding this setting will allow me to create Web Experiences through Sitecore Personalize which is option #2 for my presentation.  

## How Has This Been Tested?

Tested this locally and all went well and was able to confirm that this setting works by testing a web experience in personalize, will preview it in my local environment.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.