### PR TITLE
Removing the image from the letter hero on mobile

### DIFF
--- a/src/Project/Sugcon2024/Sugcon/src/components/Basic Components/Hero.tsx
+++ b/src/Project/Sugcon2024/Sugcon/src/components/Basic Components/Hero.tsx
@@ -133,6 +133,7 @@ export const HeroJustificationLetter = (props: HeroProps): JSX.Element => {
       direction={{ base: 'column', md: 'row' }}
       justifyContent="center"
       color="white"
+      p={5}
       w="100vw"
       maxH="400px"
       mt={24}
@@ -143,7 +144,7 @@ export const HeroJustificationLetter = (props: HeroProps): JSX.Element => {
       {/* Content box that should take the left half of the screen */}
       <Box
         mb={14}
-        w={{ base: '50vw' }} // Take full width on base, and half viewport width on md and up
+        w={{ base: 'full', md: '50vw' }}
         maxWidth="620px" // Max width is 620px
         zIndex={2}
         mr={10}
@@ -165,6 +166,7 @@ export const HeroJustificationLetter = (props: HeroProps): JSX.Element => {
         )}
       </Box>
       <Box
+        display={{ base: 'none', md: 'block' }}
         w={{ base: '50vw' }} // Take full width on base, and half viewport width on md and up
         maxWidth="620px" // Max width is 620px
       >
@@ -184,6 +186,7 @@ export const HeroJustificationLetter = (props: HeroProps): JSX.Element => {
         backgroundPosition="right bottom"
         backgroundRepeat="no-repeat"
         zIndex={0}
+        display={{ base: 'none', md: 'block' }}
       />
     </Flex>
   );


### PR DESCRIPTION
Removing the image from the letter hero on mobile to match the designs from UX.

## Description / Motivation

When we get into mobile mode we should not show the background image

## How Has This Been Tested?

Locally in Storybook

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.