### PR TITLE
Removed Engine Node from SUGCON package.json files

### DIFF
--- a/src/Project/Sugcon/SugconAnzSxa/package.json
+++ b/src/Project/Sugcon/SugconAnzSxa/package.json
@@ -18,10 +18,6 @@
       "nextjs-multisite"
     ]
   },
-  "engines": {
-    "node": ">=12",
-    "npm": ">=6"
-  },
   "author": {
     "name": "Sitecore Corporation",
     "url": "https://jss.sitecore.com"

--- a/src/Project/Sugcon/SugconEuSxa/package.json
+++ b/src/Project/Sugcon/SugconEuSxa/package.json
@@ -18,10 +18,6 @@
       "nextjs-multisite"
     ]
   },
-  "engines": {
-    "node": ">=12",
-    "npm": ">=6"
-  },
   "author": {
     "name": "Sitecore Corporation",
     "url": "https://jss.sitecore.com"

--- a/src/Project/Sugcon/SugconIndiaSxa/package.json
+++ b/src/Project/Sugcon/SugconIndiaSxa/package.json
@@ -18,10 +18,6 @@
       "nextjs-multisite"
     ]
   },
-  "engines": {
-    "node": ">=12",
-    "npm": ">=6"
-  },
   "author": {
     "name": "Sitecore Corporation",
     "url": "https://jss.sitecore.com"

--- a/src/Project/Sugcon/SugconNaSxa/package.json
+++ b/src/Project/Sugcon/SugconNaSxa/package.json
@@ -18,10 +18,6 @@
       "nextjs-multisite"
     ]
   },
-  "engines": {
-    "node": ">=12",
-    "npm": ">=6"
-  },
   "author": {
     "name": "Sitecore Corporation",
     "url": "https://jss.sitecore.com"

--- a/src/Project/Sugcon2024/Sugcon/package.json
+++ b/src/Project/Sugcon2024/Sugcon/package.json
@@ -18,10 +18,6 @@
       "nextjs-multisite"
     ]
   },
-  "engines": {
-    "node": ">=12",
-    "npm": ">=6"
-  },
   "author": {
     "name": "Sitecore Corporation",
     "url": "https://jss.sitecore.com"


### PR DESCRIPTION
Vercel have removed support for Node12, which has broken our builds. A better solution is to remove the engine definition from our `package.json`, allowing the engine to be defined within the Vercel dashboard itself. This PR makes that change.

Closes #408 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.