### PR TITLE
Updated to new XMC Docker Tools image

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -33,7 +33,7 @@ SQL_SA_PASSWORD=
 SQL_DATABASE_PREFIX=Sitecore
 
 # Other supporting images, including Sitecore modules and Docker tools
-TOOLS_IMAGE=scr.sitecore.com/tools/sitecore-docker-tools-assets:10.3-ltsc2022
+TOOLS_IMAGE=scr.sitecore.com/tools/sitecore-xmcloud-docker-tools-assets
 TRAEFIK_IMAGE=traefik:v2.11.0-windowsservercore-ltsc2022
 SOLUTION_BUILD_IMAGE=mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022
 SOLUTION_BASE_IMAGE=mcr.microsoft.com/windows/nanoserver:ltsc2022

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -266,7 +266,7 @@ services:
       args:
         PARENT_IMAGE: ${SITECORE_DOCKER_REGISTRY}sitecore-xmcloud-cm:${SITECORE_VERSION}
         SOLUTION_IMAGE: ${REGISTRY}${COMPOSE_PROJECT_NAME}-solution:${VERSION:-latest}
-        TOOLS_IMAGE: ${TOOLS_IMAGE}
+        TOOLS_IMAGE: ${TOOLS_IMAGE}:${SITECORE_VERSION}
     depends_on:
       - solution
     volumes:
@@ -293,4 +293,4 @@ services:
       Sitecore_AppSettings_exmEnabled:define: "no" # remove to turn on EXM
       MVP_RENDERING_EDITING_HOST_URI: "http://mvp-rendering/"
       RENDERING_HOST_INTERNAL_URI: ${SUGCON_EU_HOST_INTERNAL_URI}
-    entrypoint: powershell -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
+    entrypoint: powershell -Command "& C:/tools/entrypoints/iis/XmCloudDevelopment.ps1"

--- a/up.ps1
+++ b/up.ps1
@@ -64,6 +64,10 @@ if (-Not $SkipBuild) {
     Write-Host "Keeping XM Cloud base image up to date" -ForegroundColor Green
     docker pull "$($sitecoreDockerRegistry)sitecore-xmcloud-cm:$($sitecoreVersion)"
 
+    $xmcloudDockerToolsImage = ($envContent | Where-Object { $_ -imatch "^TOOLS_IMAGE=.+" }).Split("=")[1]
+    Write-Host "Keeping XM Cloud Tools image up to date" -ForegroundColor Green
+    docker pull "$($xmcloudDockerToolsImage):$($sitecoreVersion)"
+
     # Build all containers in the Sitecore instance, forcing a pull of latest base containers
     Write-Host "Building containers..." -ForegroundColor Green
     docker compose build


### PR DESCRIPTION
Updated the repo to leverage the new XMC specific Docker Tools image, as per this note in the ChangeLog: https://developers.sitecore.com/changelog/xm-cloud/new-xm-cloud-docker-tools-image

Closes #411 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.