### PR TITLE
Fix asset pointer error

### DIFF
--- a/src/Project/Sugcon2024/Sugcon/next.config.js
+++ b/src/Project/Sugcon2024/Sugcon/next.config.js
@@ -8,9 +8,6 @@ const publicUrl = getPublicUrl();
  * @type {import('next').NextConfig}
  */
 const nextConfig = {
-  // Set assetPrefix to our public URL
-  assetPrefix: publicUrl,
-
   // Allow specifying a distinct distDir when concurrently running app in a container
   distDir: process.env.NEXTJS_DIST_DIR || '.next',
 
@@ -27,7 +24,7 @@ const nextConfig = {
     // prefixed path e.g. `/styleguide`.
     defaultLocale: jssConfig.defaultLanguage,
   },
-  
+
   // Enable React Strict Mode
   reactStrictMode: true,
 
@@ -53,7 +50,7 @@ const nextConfig = {
       {
         source: '/sitecore/service/:path*',
         destination: `${jssConfig.sitecoreApiHost}/sitecore/service/:path*`,
-      }, 
+      },
     ];
   },
 };
@@ -61,4 +58,4 @@ const nextConfig = {
 module.exports = () => {
   // Run the base config through any configured plugins
   return Object.values(plugins).reduce((acc, plugin) => plugin(acc), nextConfig);
-}
+};


### PR DESCRIPTION
Remove `assetPrefix` from `next.config.js`

## Description / Motivation

I have removed the `assetPrefix` configuration from `next.config.js` because it is not required for our project's current hosting setup. The `assetPrefix` setting is utilized when Next.js applications need to serve their static assets from an offsite CDN. However, our project's assets are served directly from Vercel's CDN, which optimizes asset delivery by default. [Next.js documentation specifies](https://nextjs.org/docs/api-reference/next.config.js/asset-prefix) that deploying to Vercel automatically configures a global CDN for your project, negating the need for a manual `assetPrefix` setup.

## How Has This Been Tested?

This was tested locally, with `assetPrefix` in place I can see the assets are prefixed with `http://localhost:300`. Without the `assetPrefix` in place, assets do not have the `http://localhost:300` prefix.  Without the prefix, the page and all associated assets continue to load correctly and as expected.  This is exactly how it will work once deployed to Vercel.  We can also inspect this branch preview deployment once it is done.  This testing approach aimed to ensure that removing `assetPrefix` does not adversely affect our application's performance or user experience.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.