### PR TITLE
SUGCON24 EU: Vercel Speed Insights

### DIFF
--- a/src/Project/Sugcon2024/Sugcon/package.json
+++ b/src/Project/Sugcon2024/Sugcon/package.json
@@ -85,6 +85,7 @@
     "@types/styled-components": "^5.1.34",
     "@typescript-eslint/eslint-plugin": "^5.49.0",
     "@typescript-eslint/parser": "^5.49.0",
+    "@vercel/speed-insights": "^1.0.10",
     "chalk": "~4.1.2",
     "chokidar": "~3.5.3",
     "constant-case": "^3.0.4",

--- a/src/Project/Sugcon2024/Sugcon/src/pages/_app.tsx
+++ b/src/Project/Sugcon2024/Sugcon/src/pages/_app.tsx
@@ -1,19 +1,28 @@
 import type { AppProps } from 'next/app';
 import { I18nProvider } from 'next-localization';
 import { SitecorePageProps } from 'lib/page-props';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
 import 'assets/main.scss';
 
 function App({ Component, pageProps }: AppProps<SitecorePageProps>): JSX.Element {
   const { dictionary, ...rest } = pageProps;
 
+  // Vercel Speed Insights - Turned on and off through env variable.
+  const isSpeedInsightsEnabled =
+    process.env.NEXT_PUBLIC_ENABLE_SPEED_INSIGHTS === 'true';
+
   return (
-    // Use the next-localization (w/ rosetta) library to provide our translation dictionary to the app.
-    // Note Next.js does not (currently) provide anything for translation, only i18n routing.
-    // If your app is not multilingual, next-localization and references to it can be removed.
-    <I18nProvider lngDict={dictionary} locale={pageProps.locale}>
-      <Component {...rest} />
-    </I18nProvider>
+    <>
+      // Use the next-localization (w/ rosetta) library to provide our translation dictionary to the app.
+      // Note Next.js does not (currently) provide anything for translation, only i18n routing.
+      // If your app is not multilingual, next-localization and references to it can be removed.
+      <I18nProvider lngDict={dictionary} locale={pageProps.locale}>
+        <Component {...rest} />
+      </I18nProvider>
+
+      {isSpeedInsightsEnabled ? <SpeedInsights /> : <></>}
+    </>
   );
 }
 

--- a/src/Project/Sugcon2024/Sugcon/src/pages/_app.tsx
+++ b/src/Project/Sugcon2024/Sugcon/src/pages/_app.tsx
@@ -14,9 +14,11 @@ function App({ Component, pageProps }: AppProps<SitecorePageProps>): JSX.Element
 
   return (
     <>
-      // Use the next-localization (w/ rosetta) library to provide our translation dictionary to the app.
-      // Note Next.js does not (currently) provide anything for translation, only i18n routing.
-      // If your app is not multilingual, next-localization and references to it can be removed.
+      {/*
+       Use the next-localization (w/ rosetta) library to provide our translation dictionary to the app.
+       Note Next.js does not (currently) provide anything for translation, only i18n routing.
+       If your app is not multilingual, next-localization and references to it can be removed.
+      */}
       <I18nProvider lngDict={dictionary} locale={pageProps.locale}>
         <Component {...rest} />
       </I18nProvider>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation

Added the snippet for enabling Vercel's Speed Insights functionality for the SUGCON EU site.
https://vercel.com/sitecoretechnicalmarketing/sugcon24/speed-insights

This will allow us to track the overall performance of the site according to the Core Web Vitals standard.

I've also included an environment variable for toggling this setting. @lovesitecore you can enable this feature by adding `NEXT_PUBLIC_ENABLE_SPEED_INSIGHTS=true` to the project's environment variables.

 
## How Has This Been Tested?

I've added this snippet locally and run the site.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [] My change is a documentation change and there are NO other updates required.