### PR TITLE
Pass onToggle to Navigation children and call on link click so menu closes on route changes.

### DIFF
--- a/src/Project/Sugcon2024/Sugcon/src/components/Navigation.tsx
+++ b/src/Project/Sugcon2024/Sugcon/src/components/Navigation.tsx
@@ -54,6 +54,7 @@ export type NavigationProps = {
 interface NavigationItemProps {
   element: Fields;
   key?: number;
+  onToggle?: () => void;
   pageEditing: boolean | undefined;
 }
 
@@ -93,8 +94,20 @@ export const Default = (props: NavigationProps): JSX.Element => {
 
   const navigationMenuItems = [homeFields, ...Object.values(props.fields)];
 
-  const renderNavigation = (): JSX.Element => (
-    <ResponsiveNavigation navigationMenuItems={navigationMenuItems} pageEditing={pageEditing} />
+  interface RenderNavigationProps {
+    onToggle?: () => void;
+  }
+
+  const renderNavigation = ({
+    onToggle = () => {
+      /* intentionally left blank */
+    },
+  }: RenderNavigationProps = {}): JSX.Element => (
+    <ResponsiveNavigation
+      navigationMenuItems={navigationMenuItems}
+      onToggle={onToggle}
+      pageEditing={pageEditing}
+    />
   );
 
   return (
@@ -124,7 +137,7 @@ export const Default = (props: NavigationProps): JSX.Element => {
             borderBlockEnd="1px"
             borderBlockEndColor="sugcon.gray.300"
           >
-            {renderNavigation()}
+            {renderNavigation({ onToggle })}
           </Box>
         </Collapse>
       </Show>
@@ -134,11 +147,13 @@ export const Default = (props: NavigationProps): JSX.Element => {
 
 interface ResponsiveNavigationProps {
   navigationMenuItems: Fields[];
+  onToggle?: () => void;
   pageEditing: boolean | undefined;
 }
 
 const ResponsiveNavigation = ({
   navigationMenuItems,
+  onToggle,
   pageEditing,
 }: ResponsiveNavigationProps): JSX.Element => {
   return (
@@ -167,9 +182,13 @@ const ResponsiveNavigation = ({
                 mb={{ base: PaddingY.Desktop, lg: '0' }}
               >
                 {hasChildren ? (
-                  <NavigationItemWithChildren element={element} pageEditing={pageEditing} />
+                  <NavigationItemWithChildren
+                    element={element}
+                    onToggle={onToggle}
+                    pageEditing={pageEditing}
+                  />
                 ) : (
-                  <NavigationItem element={element} pageEditing={pageEditing} />
+                  <NavigationItem element={element} onToggle={onToggle} pageEditing={pageEditing} />
                 )}
               </ListItem>
             );
@@ -188,7 +207,11 @@ const ResponsiveNavigation = ({
   );
 };
 
-const NavigationItemWithChildren = ({ element, pageEditing }: NavigationItemProps): JSX.Element => {
+const NavigationItemWithChildren = ({
+  element,
+  onToggle,
+  pageEditing,
+}: NavigationItemProps): JSX.Element => {
   const { isOpen, getDisclosureProps, getButtonProps } = useDisclosure();
 
   const buttonProps = getButtonProps();
@@ -219,7 +242,7 @@ const NavigationItemWithChildren = ({ element, pageEditing }: NavigationItemProp
           >
             {!!element?.Children?.length &&
               element.Children.map((child, key) =>
-                renderChildNavigationItem({ element: child, key, pageEditing })
+                renderChildNavigationItem({ element: child, key, onToggle, pageEditing })
               )}
           </UnorderedList>
         </Collapse>
@@ -228,7 +251,7 @@ const NavigationItemWithChildren = ({ element, pageEditing }: NavigationItemProp
   );
 };
 
-const NavigationItem = ({ element, pageEditing }: NavigationItemProps): JSX.Element => {
+const NavigationItem = ({ element, onToggle, pageEditing }: NavigationItemProps): JSX.Element => {
   return (
     <Link
       as={SitecoreLink}
@@ -237,6 +260,7 @@ const NavigationItem = ({ element, pageEditing }: NavigationItemProps): JSX.Elem
       editable={pageEditing}
       variant="navLink"
       size={{ base: 'sm', lg: 'lg' }}
+      onClick={onToggle}
     >
       {getNavigationText(element)}
     </Link>
@@ -247,6 +271,7 @@ const NavigationItem = ({ element, pageEditing }: NavigationItemProps): JSX.Elem
 const renderChildNavigationItem = ({
   element,
   key,
+  onToggle,
   pageEditing,
 }: NavigationItemProps): JSX.Element => (
   <ListItem key={key} width="100%">
@@ -265,6 +290,7 @@ const renderChildNavigationItem = ({
         base: { backgroundColor: 'unset' },
         lg: { backgroundColor: 'sugcon.gray.100' },
       }}
+      onClick={onToggle}
     >
       {getNavigationText(element)}
     </Link>


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
When clicking a link in the mobile menu, the menu doesn't close automatically because Next.js only re-renders components that have changed. To close the menu on navigation, we pass the onToggle function to the link components and call it onClick, triggering a state change and re-render of the menu.

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Local dev and storybook.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.