### PR TITLE
SUGCON24 EU: Fix Null Reference Exception bug in ListComponents

### DIFF
--- a/src/Project/Sugcon2024/Sugcon/src/components/List Components/Accordion.tsx
+++ b/src/Project/Sugcon2024/Sugcon/src/components/List Components/Accordion.tsx
@@ -4,6 +4,7 @@ import {
   Text as JssText,
   RichTextField,
   RichText as JssRichText,
+  withDatasourceCheck,
 } from '@sitecore-jss/sitecore-jss-nextjs';
 import {
   Accordion,
@@ -16,6 +17,7 @@ import {
 } from '@chakra-ui/react';
 import { isEditorActive } from '@sitecore-jss/sitecore-jss-nextjs/utils';
 import { LayoutFlex } from 'components/Templates/LayoutFlex';
+import { ComponentProps } from 'lib/component-props';
 
 interface AccordionElement {
   fields: {
@@ -35,12 +37,11 @@ interface Fields {
   Elements: Array<AccordionElement>;
 }
 
-interface AccordionProps {
-  params: { [key: string]: string };
+type AccordionProps = ComponentProps & {
   fields: Fields;
-}
+};
 
-export const Default = (props: AccordionProps): JSX.Element => {
+const AccordionComponent = (props: AccordionProps): JSX.Element => {
   return (
     <LayoutFlex direction="column">
       {(isEditorActive() || props.fields?.Headline?.value !== '') && (
@@ -71,3 +72,5 @@ export const Default = (props: AccordionProps): JSX.Element => {
     </LayoutFlex>
   );
 };
+
+export const Default = withDatasourceCheck()<AccordionProps>(AccordionComponent);

--- a/src/Project/Sugcon2024/Sugcon/src/components/List Components/PeopleGrid.tsx
+++ b/src/Project/Sugcon2024/Sugcon/src/components/List Components/PeopleGrid.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Box, Heading, SimpleGrid } from '@chakra-ui/react';
-import { TextField, Text as JssText } from '@sitecore-jss/sitecore-jss-nextjs';
+import { TextField, Text as JssText, withDatasourceCheck } from '@sitecore-jss/sitecore-jss-nextjs';
 import { PersonFields, PersonProps, Default as Person } from '../Basic Components/Person';
 import clsx from 'clsx';
 import { LayoutFlex } from 'components/Templates/LayoutFlex';
+import { ComponentProps } from 'lib/component-props';
 
 // Define the type of props that People Grid will accept
 interface Fields {
@@ -32,12 +33,11 @@ interface Person {
   url: string;
 }
 
-export type PeopleGridProps = {
-  params: { [key: string]: string };
+export type PeopleGridProps = ComponentProps & {
   fields: Fields;
 };
 
-export const Default = (props: PeopleGridProps): JSX.Element => {
+const PeopleGridComponent = (props: PeopleGridProps): JSX.Element => {
   const cols = props.params && props.params.Columns ? parseInt(props.params.Columns) : 4;
 
   if (props.params && props.params.Alphabetize == '1') {
@@ -71,3 +71,5 @@ export const Default = (props: PeopleGridProps): JSX.Element => {
     </Box>
   );
 };
+
+export const Default = withDatasourceCheck()<PeopleGridProps>(PeopleGridComponent);

--- a/src/Project/Sugcon2024/Sugcon/src/components/List Components/SpeakersGrid.tsx
+++ b/src/Project/Sugcon2024/Sugcon/src/components/List Components/SpeakersGrid.tsx
@@ -1,9 +1,15 @@
 import { useState, useEffect } from 'react';
 import { Box, Heading, SimpleGrid } from '@chakra-ui/react';
-import { Field, TextField, Text as JssText } from '@sitecore-jss/sitecore-jss-nextjs';
+import {
+  Field,
+  TextField,
+  Text as JssText,
+  withDatasourceCheck,
+} from '@sitecore-jss/sitecore-jss-nextjs';
 import { PersonFields, PersonProps, Default as Person } from '../Basic Components/Person';
 import * as cheerio from 'cheerio';
 import clsx from 'clsx';
+import { ComponentProps } from 'lib/component-props';
 
 // Define the type of props that People Grid will accept
 interface Fields {
@@ -35,8 +41,7 @@ interface PersonItem {
   url: string;
 }
 
-export type PeopleGridProps = {
-  params: { [key: string]: string };
+export type PeopleGridProps = ComponentProps & {
   fields: Fields;
 };
 
@@ -100,7 +105,7 @@ function getPeople(sessionTitle: string, body: string) {
   return people;
 }
 
-export const Default = (props: PeopleGridProps): JSX.Element => {
+const PeopleGridComponent = (props: PeopleGridProps): JSX.Element => {
   const cols = props.params && props.params.Columns ? parseInt(props.params.Columns) : 5;
 
   const [people, setPeople] = useState(Array<PersonItem>);
@@ -148,3 +153,5 @@ export const Default = (props: PeopleGridProps): JSX.Element => {
     </Box>
   );
 };
+
+export const Default = withDatasourceCheck()<PeopleGridProps>(PeopleGridComponent);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
If the Data Source of `Accordion` rendering is empty, the rendering host will return a 500 Internal Server Error. The same issue exists with `PeopleGrid` and `SpeakersGrid` renderings as well.

![image](https://github.com/Sitecore/XM-Cloud-Introduction/assets/20036944/c855a972-213f-4ef0-8300-3bc7c7b012f6)
![image](https://github.com/Sitecore/XM-Cloud-Introduction/assets/20036944/5bf3c89f-0cab-453b-9497-1a0c0c2fbef5)
![image](https://github.com/Sitecore/XM-Cloud-Introduction/assets/20036944/d9c7f283-0af2-4a84-bf6e-14351f30450c)


<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.