### PR TITLE
Call dangerously set to allow script tags

### DIFF
--- a/src/Project/Sugcon2024/Sugcon/package.json
+++ b/src/Project/Sugcon2024/Sugcon/package.json
@@ -47,6 +47,7 @@
     "bootstrap": "^5.1.3",
     "cheerio": "^1.0.0-rc.12",
     "clsx": "^2.1.0",
+    "dangerously-set-html-content": "^1.1.0",
     "font-awesome": "^4.7.0",
     "framer-motion": "^10.18.0",
     "graphql": "~15.8.0",

--- a/src/Project/Sugcon2024/Sugcon/src/components/Events/Agenda.tsx
+++ b/src/Project/Sugcon2024/Sugcon/src/components/Events/Agenda.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import InnerHTML from 'dangerously-set-html-content';
 import { Field } from '@sitecore-jss/sitecore-jss-nextjs';
 import useSWR from 'swr';
 
@@ -45,7 +46,7 @@ export const Default = (props: AgendaProps): JSX.Element => {
   return (
     <div className={`component agenda ${props.params.styles}`} id={id ? id : undefined}>
       <div className="component-content">
-        <div dangerouslySetInnerHTML={{ __html: data as string }} />
+        <InnerHTML html={data} />
       </div>
     </div>
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

On the agenda page, the popup for the session details was not opening.  The html from sessionize includes the javascript function to open the modal.  The dangerouslySetHtml attribute does not render script tags. I used this node module https://www.npmjs.com/package/dangerously-set-html-content.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

![image](https://github.com/Sitecore/XM-Cloud-Introduction/assets/21204526/3d2f35af-89b8-4eda-a395-19d4707743f2)

![image](https://github.com/Sitecore/XM-Cloud-Introduction/assets/21204526/9e59a09c-c6ba-4438-a967-f7ec9da57800)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.