### PR TITLE
Fix images for PeopleGrid Component

### DIFF
--- a/src/Project/Sugcon2024/Sugcon/src/components/Basic Components/Person.tsx
+++ b/src/Project/Sugcon2024/Sugcon/src/components/Basic Components/Person.tsx
@@ -72,7 +72,6 @@ export const Default = (props: PersonProps): JSX.Element => {
         field={props.fields.Image}
         objectFit="cover"
         boxSize="300px"
-        alt={props.fields.Image?.value?.alt}
       />
       {props.params?.LinkToBio == '1' && (
         <Button onClick={onOpen} variant="link">

--- a/src/Project/Sugcon2024/Sugcon/src/components/Basic Components/Person.tsx
+++ b/src/Project/Sugcon2024/Sugcon/src/components/Basic Components/Person.tsx
@@ -70,6 +70,9 @@ export const Default = (props: PersonProps): JSX.Element => {
         onClick={props.params?.LinkToBio == '1' ? onOpen : undefined}
         cursor="pointer"
         field={props.fields.Image}
+        objectFit="cover"
+        boxSize="300px"
+        alt={props.fields.Image?.value?.alt}
       />
       {props.params?.LinkToBio == '1' && (
         <Button onClick={onOpen} variant="link">

--- a/src/Project/Sugcon2024/Sugcon/src/components/Basic Components/Venue.tsx
+++ b/src/Project/Sugcon2024/Sugcon/src/components/Basic Components/Venue.tsx
@@ -110,7 +110,6 @@ export const Default = (props: VenueProps): JSX.Element => {
                   height="100%"
                   maxHeight="400px"
                   objectFit="cover"
-                  alt={image?.fields?.alt}
                 />
               ))}
             </Slider>

--- a/src/Project/Sugcon2024/Sugcon/src/components/Basic Components/Venue.tsx
+++ b/src/Project/Sugcon2024/Sugcon/src/components/Basic Components/Venue.tsx
@@ -110,6 +110,7 @@ export const Default = (props: VenueProps): JSX.Element => {
                   height="100%"
                   maxHeight="400px"
                   objectFit="cover"
+                  alt={image?.fields?.alt}
                 />
               ))}
             </Slider>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
The People Grid Component is used in 2 different occasions: The Featured Speakers and the organizers. In both cases, the Images of each person should be displayed as a square with rounded edges. When using images that are not cropped to square the layout looks odd. So the css should handle the cropping to preserve the layout. 

Added the object-fit: cover attribute along with an additional alt attribute to improve Lighthouse Scores and Accessibility. 


## How Has This Been Tested?

Test locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.