### PR TITLE
fix hero component by removing paddings and increasing width to 100 p…

### DIFF
--- a/src/Project/Sugcon2024/Sugcon/src/assets/sass/components/container/_zero-padding.scss
+++ b/src/Project/Sugcon2024/Sugcon/src/assets/sass/components/container/_zero-padding.scss
@@ -1,0 +1,4 @@
+.zero-padding {
+    padding-left: 0px;
+    padding-right: 0px;
+}

--- a/src/Project/Sugcon2024/Sugcon/src/assets/sass/components/container/index.scss
+++ b/src/Project/Sugcon2024/Sugcon/src/assets/sass/components/container/index.scss
@@ -1,1 +1,2 @@
 @import "bordered";
+@import "zero-padding";

--- a/src/Project/Sugcon2024/Sugcon/src/components/Basic Components/Hero.tsx
+++ b/src/Project/Sugcon2024/Sugcon/src/components/Basic Components/Hero.tsx
@@ -43,7 +43,7 @@ export type HeroProps = {
 
 export const HeroHomepage = (props: HeroProps): JSX.Element => {
   return (
-    <Flex flexDir={{ base: 'column', md: 'row' }}>
+    <Flex flexDir={{ base: 'column', md: 'row' }} width="100%" paddingRight="0px" paddingLeft="0px">
       <Box
         ml="auto"
         maxW={{ base: '100%', md: `calc((${Template.MaxWidth}) / 2)` }}
@@ -85,6 +85,7 @@ export const HeroHomepage = (props: HeroProps): JSX.Element => {
         />
       </Flex>
     </Flex>
+    
   );
 };
 

--- a/src/Project/Sugcon2024/items/SiteShared/Shared/Presentation/Partial Designs/Generic Page.yml
+++ b/src/Project/Sugcon2024/items/SiteShared/Shared/Presentation/Partial Designs/Generic Page.yml
@@ -10,7 +10,7 @@ SharedFields:
 - ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
   Hint: __Thumbnail
   Value: |
-    <image mediaid="{BA725D1B-ED0B-494B-96D9-F3006EA04368}" />
+    <image mediaid="{9CA09510-BA4A-4C79-AFA4-C2754084F32D}" />
 - ID: "f1a1fe9e-a60c-4ddb-a3a0-bb5b29fe732e"
   Hint: __Renderings
   Value: |
@@ -28,7 +28,7 @@ SharedFields:
           uid="{E0C2CC68-0CB5-4A39-B2EA-60835E683EE0}"
           p:after="*[1=2]"
           s:id="{7A1D9A21-B8D7-42F9-9B0B-92ABF8D1974F}"
-          s:par="GridParameters=%7B7465D855-992E-4DC2-9855-A03250DFA74B%7D&amp;FieldNames&amp;BackgroundImage&amp;Styles&amp;CacheClearingBehavior=Clear%20on%20publish&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=2"
+          s:par="GridParameters=%7B7465D855-992E-4DC2-9855-A03250DFA74B%7D&amp;FieldNames&amp;BackgroundImage&amp;Styles=%7B855580BE-946E-4796-83DA-6E61E92B75CA%7D&amp;CacheClearingBehavior=Clear%20on%20publish&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=2"
           s:ph="headless-main" />
       </d>
     </r>
@@ -42,7 +42,16 @@ Languages:
       Value: <r />
     - ID: "04bf00db-f5fb-41f7-8ab7-22408372a981"
       Hint: __Final Renderings
-      Value: 
+      Value: |
+        <r xmlns:p="p" xmlns:s="s"
+          p:p="1">
+          <d
+            id="{FE5D7FDF-89C0-4D99-9AA3-B5FBD009C9F3}">
+            <r
+              uid="{E0C2CC68-0CB5-4A39-B2EA-60835E683EE0}"
+              s:par="GridParameters=%7B7465D855-992E-4DC2-9855-A03250DFA74B%7D&amp;FieldNames&amp;BackgroundImage&amp;Styles=%7B855580BE-946E-4796-83DA-6E61E92B75CA%7D&amp;CacheClearingBehavior=Clear%20on%20publish&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=2" />
+          </d>
+        </r>
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
       Value: 20240123T184241Z
@@ -56,11 +65,11 @@ Languages:
         sitecore\UOUBIWQRx7
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "da45bf49-8692-4ad5-b0fc-fc7c3304a61c"
+      Value: "0c139e49-3da2-4d99-ae27-f4d672836784"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\UOUBIWQRx7
+        sitecore\UzWooIJE3y
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240409T130119Z
+      Value: 20240426T143206Z

--- a/src/Project/Sugcon2024/items/SiteShared/Shared/Presentation/Styles/Container/Zero Padding.yml
+++ b/src/Project/Sugcon2024/items/SiteShared/Shared/Presentation/Styles/Container/Zero Padding.yml
@@ -1,0 +1,41 @@
+﻿---
+ID: "855580be-946e-4796-83da-6e61e92b75ca"
+Parent: "a99dfe78-766f-4d85-98e5-a692435cc5f6"
+Template: "6b8aabef-d650-46e0-97d0-c0b04f7f016b"
+Path: /sitecore/content/Sugcon2024/Shared/Presentation/Styles/Container/Zero Padding
+SharedFields:
+- ID: "09147fb2-ebfb-4949-8c8e-26a424409d5e"
+  Hint: Value
+  Value: "zero-padding"
+- ID: "69bb49f3-da64-4b0e-abd6-184b832ff6ab"
+  Hint: Allowed Renderings
+  Value: "{7A1D9A21-B8D7-42F9-9B0B-92ABF8D1974F}"
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 4100
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20240426T142837Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\UzWooIJE3y
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\UzWooIJE3y
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "f4982346-2140-461f-aa4a-0da1b4397e5f"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\UzWooIJE3y
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20240426T142925Z


### PR DESCRIPTION
fix hero component by removing paddings and increasing width to 100 percent. Also container style has been adjusted by using style items in shared site. (only Hero Homepage Varinat)

## Description / Motivation

Hero component showed gaps (padding) on the right depending on image size. Also the text was shifted to the left. The width of the hero component has been set to 100% which looks good on desktop and mobile.

for using  Hero component on Generic Page Designs the container used as placeholder has been adjusted as well. I added a style item named zero padding and applied it to the container used on the Generic Page Partial Design.

## How Has This Been Tested?

this has been tested on local.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the Contributing guide.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.