### PR TITLE
Fixed padding top and applied same component structure as Other Hero Variant

### DIFF
--- a/src/Project/Sugcon2024/Sugcon/src/components/Basic Components/Hero.tsx
+++ b/src/Project/Sugcon2024/Sugcon/src/components/Basic Components/Hero.tsx
@@ -91,52 +91,57 @@ export const HeroHomepage = (props: HeroProps): JSX.Element => {
 
 export const HeroEvent = (props: HeroProps): JSX.Element => {
   return (
-    <Flex
-      direction={{ base: 'row', md: 'row' }}
-      alignItems="center"
+    <>
+    <Flex 
+      flexDir={{ base: 'column', md: 'row' }} 
+      width="100%" 
+      paddingRight="0px" 
+      paddingLeft="0px"
       bg="black"
       color="white"
-      maxHeight={{ base: 'auto', md: '400px' }}
-      m="auto"
-      maxW="1240px"
-      pt={10}
-    >
-      <Flex
-        direction="column"
+      >
+      <Box
         ml="auto"
         maxW={{ base: '100%', md: `calc((${Template.MaxWidth}) / 2)` }}
         px={{ base: PaddingX.Mobile, md: PaddingX.Desktop }}
         py={{ base: '30px', md: '60px' }}
       >
-        <Box width="auto" alignSelf="end">
-          <Heading as="h1" fontSize="3xl" fontWeight="bold" mb="33px">
-            <JssText field={props.fields.Headline} />
-          </Heading>
+        <Heading as="h1" fontSize="3xl" fontWeight="bold" mb="33px">
+          <JssText field={props.fields.Headline} />
+        </Heading>
 
-          {isSitecoreTextFieldPopulated(props.fields.Text) && (
-            <Text fontSize="18px">
-              <JssText field={props.fields.Text} />
-            </Text>
-          )}
-        </Box>
-      </Flex>
-      <Box
-        minWidth={{ base: '100%', md: '50%' }}
-        maxHeight="400px"
-        h="100%"
-        maxWidth="620px"
-        overflow="hidden"
-      >
-        <Image
-          src={props.fields.Image?.value?.src}
-          //alt={props.fields.Image?.value?.alt}
-          width="full"
-          height="100%"
-          maxHeight="400px"
-          objectFit="cover"
-        />
+        {isSitecoreTextFieldPopulated(props.fields.EventDate) && (
+          <Text fontSize="18px" mb={6}>
+            <JssText field={props.fields.EventDate} />
+          </Text>
+        )}
+
+        {isSitecoreTextFieldPopulated(props.fields.Text) && (
+          <Text mb={6} fontSize="18px">
+            <JssText field={props.fields.Text} />
+          </Text>
+        )}
+
+        {isSitecoreLinkFieldPopulated(props.fields.CallToAction) && (
+          <Box width="auto" alignSelf="start">
+            <ButtonLink field={props.fields.CallToAction} />
+          </Box>
+        )}
       </Box>
+      <Flex flexGrow={{ md: 'grow' }} maxW={{ base: '100%', md: '50%' }}>
+        <Image
+          alt="Event Image"
+          w="full"
+          h="auto"
+          objectFit="cover"
+          objectPosition="center"
+          aspectRatio="1440/500"
+          src={props.fields.Image?.value?.src}
+          minH="220px"
+        />
+      </Flex>
     </Flex>
+    </>
   );
 };
 


### PR DESCRIPTION
The Event Variant of Hero Banner had a padding at the top. So I exchanged the markup with the one that has been fixed for the main variant and change background to black and font color  to white.

## Description / Motivation

see above
## How Has This Been Tested?

tested locally

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.