### PR TITLE
#feature/tag-similar-to-foundation-head-dev: removed confusing siteco…

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -23,7 +23,7 @@ NODE_ENV=development
 SITECORE_DOCKER_REGISTRY=scr.sitecore.com/xmcloud/
 SITECORE_NONPRODUCTION_DOCKER_REGISTRY=scr.sitecore.com/sxp/
 SITECORE_VERSION=1-ltsc2022
-EXTERNAL_IMAGE_TAG_SUFFIX=10.2-ltsc2022
+EXTERNAL_IMAGE_TAG_SUFFIX=ltsc2022
 
 # The sitecore\admin and SQL 'sa' account passwords for this environment are configurable here.
 SITECORE_ADMIN_PASSWORD=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
         condition: service_healthy
   solr:
     isolation: ${ISOLATION}
-    image: ${SITECORE_NONPRODUCTION_DOCKER_REGISTRY}nonproduction/solr:8.8.2-${EXTERNAL_IMAGE_TAG_SUFFIX}
+    image: ${SITECORE_NONPRODUCTION_DOCKER_REGISTRY}nonproduction/solr:8.11.2-${EXTERNAL_IMAGE_TAG_SUFFIX}
     ports:
       - "8984:8983"
     volumes:


### PR DESCRIPTION
Since this is XMC project, removed confusing sitecore version-based tag and updated solr version based on foundation dev head project

## Description / Motivation

This is confusing since XMC is independent of Sitecore version-based release

## How Has This Been Tested?

Did a container up and start:
![image](https://github.com/Sitecore/XM-Cloud-Introduction/assets/55013802/6c199dd1-c4ec-4f0d-924a-8eb9658e6354)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.