### PR TITLE
Changed XMC DevOps process to use Promote

### DIFF
--- a/.github/workflows/CI-CD_XM_Cloud.yml
+++ b/.github/workflows/CI-CD_XM_Cloud.yml
@@ -42,12 +42,13 @@ jobs:
       XM_CLOUD_CLIENT_SECRET: ${{ secrets.XM_CLOUD_CLIENT_SECRET }}
       XM_CLOUD_ENVIRONMENT_ID: ${{ secrets.STAGING_XM_CLOUD_ENVIRONMENT_ID }}
 
-  deploy-prod:
+  promote-to-prod:
     if: github.ref == 'refs/heads/main'
     needs: deploy-staging 
-    uses: ./.github/workflows/deploy_xmCloud.yml
+    uses: ./.github/workflows/promote_xmCloud.yml
     with:
       environmentName: Production
+      deploymentId: ${{ needs.deploy-staging.outputs.completedDeploymentId }}
     secrets:
       XM_CLOUD_CLIENT_ID: ${{ secrets.XM_CLOUD_CLIENT_ID }}
       XM_CLOUD_CLIENT_SECRET: ${{ secrets.XM_CLOUD_CLIENT_SECRET }}

--- a/.github/workflows/deploy_xmCloud.yml
+++ b/.github/workflows/deploy_xmCloud.yml
@@ -34,6 +34,7 @@ jobs:
     - name: Authenticate CLI with XM Cloud
       run: dotnet sitecore cloud login --client-credentials --client-id ${{ secrets.XM_CLOUD_CLIENT_ID }} --client-secret ${{ secrets.XM_CLOUD_CLIENT_SECRET }} --allow-write
     - name: Deploy the CM assets to XM Cloud
+      id: run-deployment
       run: |
         result=$(dotnet sitecore cloud deployment create --environment-id ${{ secrets.XM_CLOUD_ENVIRONMENT_ID }} --upload --json)
         echo $result

--- a/.github/workflows/promote_xmCloud.yml
+++ b/.github/workflows/promote_xmCloud.yml
@@ -1,4 +1,4 @@
-name: Deploy the solution and items to an XM Cloud instance
+name: Promote an XM Cloud deployment to a different environment.
 
 on:
   workflow_call:
@@ -6,9 +6,9 @@ on:
       environmentName:
         required: true
         type: string
-    outputs:
-      completedDeploymentId:
-        value: '${{ jobs.deploy.outputs.completedDeploymentId }}'
+      deploymentId:
+        required: true
+        type: string
     secrets:
       XM_CLOUD_CLIENT_ID:
         required: true
@@ -20,10 +20,8 @@ on:
 jobs:
 
   deploy:
-    name: Deploy the XM Cloud ${{ inputs.environmentName }} Site
+    name: Promoting XM Cloud Deployment ${{ inputs.deploymentId }} to ${{ inputs.environmentName }} Site
     runs-on: ubuntu-latest
-    outputs:
-      completedDeploymentId: ${{ steps.run-deployment.outputs.completedDeploymentId }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-dotnet@v2
@@ -35,7 +33,7 @@ jobs:
       run: dotnet sitecore cloud login --client-credentials --client-id ${{ secrets.XM_CLOUD_CLIENT_ID }} --client-secret ${{ secrets.XM_CLOUD_CLIENT_SECRET }} --allow-write
     - name: Deploy the CM assets to XM Cloud
       run: |
-        result=$(dotnet sitecore cloud deployment create --environment-id ${{ secrets.XM_CLOUD_ENVIRONMENT_ID }} --upload --json)
+        result=$(dotnet sitecore cloud environment promote --environment-id ${{ secrets.XM_CLOUD_ENVIRONMENT_ID }} --source-id ${{ inputs.deploymentId }} --json)
         echo $result
         isTimedOut=$(echo $result | jq ' .IsTimedOut')
         isCompleted=$(echo $result | jq ' .IsCompleted')
@@ -50,4 +48,3 @@ jobs:
             exit -1
         fi
         echo "Deployment Completed"
-        echo "completedDeploymentId=$deploymentId" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Currently the CI/CD Pipeline for XMC runs a build for both Staging and Prod envs, The aim has always been to promote the successful build from Staging to Prod, instead of building again as that slows down the deployment process.

This was blocked previously due to a missing feature in the CLI, that feature has been added and this change now updates the process accordingly.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.

Resolves #230 