### PR TITLE
white box for mobile Hero to increase contrast

### DIFF
--- a/headapps/MvpSite/MvpSite.Rendering/wwwroot/sass/components/hero.scss
+++ b/headapps/MvpSite/MvpSite.Rendering/wwwroot/sass/components/hero.scss
@@ -367,6 +367,11 @@
         width: 100%;
       }
     }
+    .col-12 {
+      background-color: rgba(255, 255, 255, 0.9);
+      padding: 15px;
+      max-width: 90%;
+    }
   }
 }
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

The HeroBig rendering used on the homepage has a bad contrast when it comes to the overlay text and the background image. For mobile resolutions a white transparent box is added to increase contrast for the overlay text.

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested on local. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.