### PR TITLE
Admin session results are no longer cached

### DIFF
--- a/headapps/MvpSite/Directory.Packages.props
+++ b/headapps/MvpSite/Directory.Packages.props
@@ -21,7 +21,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Session" Version="2.2.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="7.3.1" />
     <PackageVersion Include="Okta.AspNetCore" Version="4.5.0" />
-    <PackageVersion Include="Mvp.Selections.Client" Version="4.18.0" />
+    <PackageVersion Include="Mvp.Selections.Client" Version="4.19.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageVersion Include="Markdig" Version="0.37.0" />
   </ItemGroup>

--- a/headapps/MvpSite/MvpSite.Rendering/Helpers/MvpSelectionsApiHelper.cs
+++ b/headapps/MvpSite/MvpSite.Rendering/Helpers/MvpSelectionsApiHelper.cs
@@ -1,0 +1,24 @@
+﻿using System.Net;
+using Mvp.Selections.Client;
+using Mvp.Selections.Client.Models;
+using Mvp.Selections.Domain;
+
+namespace MvpSite.Rendering.Helpers;
+
+public class MvpSelectionsApiHelper(MvpSelectionsApiClient client)
+{
+    public async Task<bool> IsCurrentUserAnAdmin()
+    {
+        bool isAdmin = false;
+        if (await client.IsAuthenticatedAsync())
+        {
+            Response<User> currentUserResponse = await client.GetCurrentUserAsync();
+            if (currentUserResponse is { StatusCode: HttpStatusCode.OK, Result: not null })
+            {
+                isAdmin = currentUserResponse.Result.HasRight(Right.Admin);
+            }
+        }
+
+        return isAdmin;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation

<!--- Describe your changes in detail -->
Alters the cache behavior for requests made by administrators

<!--- Why is this change required? What problem does it solve? -->
Previously the results of the requests for Directory searches and profiles were cached without regard for the access level of the requester. This could lead to future titles being cached and served to non-privileged users. This ensures that admin requests are never cached.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Manual UI testing

<!--- Include details of your testing environment, and the tests you ran to -->
Local Docker

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.