### PR TITLE
Remove max width wide screens for h2 in page-overview-panel

### DIFF
--- a/headapps/MvpSite/MvpSite.Rendering/wwwroot/style/main.css
+++ b/headapps/MvpSite/MvpSite.Rendering/wwwroot/style/main.css
@@ -3547,9 +3547,15 @@ form#confirmationForm [type=checkbox]:checked {
   display: block;
   width: 85%;
 }
+
+@media (max-width: 991.98px) {
+    .page-overview-panel h2 {
+        max-width: 720px;
+    }
+}
+
 .page-overview-panel h2 {
   margin-bottom: 30px;
-  max-width: 720px;
   font-size: var(--sc-h4);
   line-height: var(--sc-h4-lh);
   letter-spacing: var(--sc-h4-ls);


### PR DESCRIPTION
## Description / Motivation
This PR removes the max width restriction on h2 headings in the page-overview-panel.

## How Has This Been Tested?
Local

Can be tested on the become-an-mvp page (https://mvp.sitecore.com/Become-an-mvp).
The line: "What kind of Community contribution is needed?" should not break.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.