### PR TITLE
Remove version from css reference

### DIFF
--- a/headapps/MvpSite/MvpSite.Rendering/Views/Shared/_Layout.cshtml
+++ b/headapps/MvpSite/MvpSite.Rendering/Views/Shared/_Layout.cshtml
@@ -35,7 +35,7 @@
     
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-    <link rel="stylesheet" href="/style/main.min.css?v=2.22" />
+    <link rel="stylesheet" href="/style/main.min.css" />
 
     @if (this.SitecoreContext() != null && this.SitecoreContext()!.IsEditing)
     {


### PR DESCRIPTION
## Description / Motivation
This PR removes the version indicator from the main.min.css reference in the head which prevents loading latest version

## How Has This Been Tested?
Local

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.