### PR TITLE
Changed ANZ to use dedicated page templates

### DIFF
--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Home.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Home.yml
@@ -1,7 +1,7 @@
 ﻿---
 ID: "104aab05-98db-4152-a2fe-95e7fc9a3c87"
 Parent: "fc8898e5-4db0-4825-bb88-745478f0e376"
-Template: "28f60da7-21f8-4791-9ecf-f65a93e105a4"
+Template: "f73d4c6d-f7e5-4e9f-838b-f60abb54a4c2"
 Path: /sitecore/content/Sugcon2024/ANZ/Home
 BranchID: "45cf9f42-b3ac-4412-aab9-f8441c7e448e"
 SharedFields:
@@ -14,7 +14,7 @@ SharedFields:
 - ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
   Hint: __Thumbnail
   Value: |
-    <image mediaid="{D1C8DA27-9335-4FF6-89AC-4C3786E053C2}" />
+    <image mediaid="{76DD9088-47BC-47F5-9A1C-5555701A2946}" />
 - ID: "dec8d2d5-e3cf-48b6-a653-8e69e2716641"
   Hint: __Security
   Value: |
@@ -60,29 +60,15 @@ Languages:
               s:par="GridParameters=%7B7465D855-992E-4DC2-9855-A03250DFA74B%7D&amp;FieldNames&amp;Styles&amp;CacheClearingBehavior=Clear%20on%20publish&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=5"
               s:ph="headless-main" />
             <r
-              uid="{DDAB2826-BDFB-423D-B9E6-2F818B967BF5}"
-              p:after="r[@uid='{5D83486D-6577-4FB5-B5FF-FEE88A5E6338}']"
-              s:ds="131AAB36-7E52-48E9-9999-9E506117586E"
-              s:id="{53331DB4-9E80-4727-B7A6-2617BEA59142}"
-              s:par="GridParameters=%7B7465D855-992E-4DC2-9855-A03250DFA74B%7D&amp;Columns&amp;Alphabetize&amp;LinkToBio&amp;DisplaySocialLinks=1&amp;FieldNames&amp;Styles=%7C%7B9D3C0CCC-2FEB-4351-BC34-970E0941E835%7D&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=7"
-              s:ph="headless-main" />
-            <r
               uid="{6F7DCBAA-608B-4728-BD56-9C00ABEBFDF8}"
-              p:after="r[@uid='{DDAB2826-BDFB-423D-B9E6-2F818B967BF5}']"
+              p:after="r[@uid='{5D83486D-6577-4FB5-B5FF-FEE88A5E6338}']"
               s:ds="23CDF32E-11F0-4ACA-AD68-20AD06B170E2"
               s:id="{53238441-0A66-46B8-BAE6-34A771BFF798}"
               s:par="GridParameters=%7B7465D855-992E-4DC2-9855-A03250DFA74B%7D&amp;FieldNames&amp;Styles&amp;CacheClearingBehavior=Clear%20on%20publish&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=3"
               s:ph="headless-main" />
             <r
-              uid="{8A21EA5A-666A-4086-9835-FD891471039D}"
-              p:after="r[@uid='{6F7DCBAA-608B-4728-BD56-9C00ABEBFDF8}']"
-              s:ds="c1c1b59a-28fb-4255-afc0-332ba474690e"
-              s:id="{CD6AD0C7-2D3E-4815-93B4-E6F4B88580AA}"
-              s:par="GridParameters=%7B7465D855-992E-4DC2-9855-A03250DFA74B%7D&amp;FieldNames&amp;Styles&amp;CacheClearingBehavior=Clear%20on%20publish&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=6"
-              s:ph="headless-main" />
-            <r
               uid="{323964F9-3701-443B-9FEE-FBDFB9D4599A}"
-              p:after="r[@uid='{8A21EA5A-666A-4086-9835-FD891471039D}']"
+              p:after="r[@uid='{6F7DCBAA-608B-4728-BD56-9C00ABEBFDF8}']"
               s:ds="7188BA27-7401-4408-9521-33D5B93AC468"
               s:id="{66DF59E9-F066-42F2-8F67-3E3F50B6E585}"
               s:par="GridParameters=%7B7465D855-992E-4DC2-9855-A03250DFA74B%7D&amp;FieldNames&amp;Styles&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=9"
@@ -99,7 +85,7 @@ Languages:
     - ID: "1c75d8e4-860f-4a6f-86f5-e0868d0114f1"
       Hint: OGImage
       Value: |
-        <image mediaid="{0BE1CD1C-6448-4156-B8A5-548C81507908}" />
+        <image mediaid="{6DD6D8B3-0233-4D50-ABF9-115C6267F80C}" />
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
       Value: 20240105T121410Z
@@ -119,26 +105,26 @@ Languages:
       Value: website
     - ID: "7d817b40-bd80-41e3-8562-5ec5f3fb95fd"
       Hint: MetaDescription
-      Value: Join us at SUGCON ANZ 2023, the premier ANZ conference for Sitecore professionals. Learn from experts, network with peers, and explore the latest in Sitecore technology.
+      Value: Join us at SUGCON ANZ 2025, the premier ANZ conference for Sitecore professionals. Learn from experts, network with peers, and explore the latest in Sitecore technology.
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "5fd24934-72c4-4f04-9294-de9c7340984e"
+      Value: "3fa318fd-b177-4e2c-90fa-63448bbeef72"
     - ID: "b03cdc17-d7b5-4c87-97a9-b57352fe54a3"
       Hint: OGTitle
-      Value: SUGCON ANZ 2023 | The ANZ Sitecore User Group Conference
+      Value: SUGCON ANZ 2025 | The ANZ Sitecore User Group Conference
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\sebastian.winter@sitecore.com
+        sitecore\Rob Earlam
     - ID: "cbb2a914-81e3-4fe6-8aed-deab8ed8b98e"
       Hint: OGDescription
-      Value: Join us at SUGCON ANZ 2023, the premier ANZ conference for Sitecore professionals. Learn from experts, network with peers, and explore the latest in Sitecore technology.
+      Value: Join us at SUGCON ANZ 2025, the premier ANZ conference for Sitecore professionals. Learn from experts, network with peers, and explore the latest in Sitecore technology.
     - ID: "d71d9097-062c-4781-bae9-d6658ab01ade"
       Hint: MetaKeywords
       Value: SUGCON, ANZ, Sitecore, User Group, Conference, Technology, Web Development, Digital Experience, CMS
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240424T130445Z
-    - ID: "ecefdd88-c772-4eab-9faf-24b23e769f27"
+      Value: 20250605T004154Z
+    - ID: "dac03f58-2882-4106-aada-b35f653537a6"
       Hint: Title
-      Value: Join us at SUGCON Europe 2024, the premier European conference for Sitecore professionals.
+      Value: Join us at SUGCON ANZ 2025, the premier conference in Australia and New Zealand for Sitecore professionals.

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Home/Agenda.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Home/Agenda.yml
@@ -1,16 +1,25 @@
 ﻿---
 ID: "7c9f3ed5-e12a-4ff9-a0b8-ff9bd68ce9e0"
 Parent: "104aab05-98db-4152-a2fe-95e7fc9a3c87"
-Template: "f5d59b30-223d-4e5a-967d-19daf7934db6"
+Template: "a094d215-ec24-4a11-a9c3-ef44c7cb7826"
 Path: /sitecore/content/Sugcon2024/ANZ/Home/Agenda
 SharedFields:
+- ID: "1fbc6a49-6281-48ee-87e9-a3970b145adb"
+  Hint: NavigationFilter
+  Value: "{D063E9D1-C7B5-4B1E-B31E-69886C9C59F5}"
+- ID: "9135200a-5626-4dd8-ab9d-d665b8c11748"
+  Hint: __Never publish
+  Value: 1
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
   Value: 200
 - ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
   Hint: __Thumbnail
   Value: |
-    <image mediaid="{647E5005-A2F5-48AF-899D-CE918D3BCF15}" />
+    <image mediaid="{4F433829-D21B-4DAA-9DFA-4CE239B1921B}" />
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "dab8a4c9-84b0-47a8-adf7-c7f0bf9a4e9b"
 Languages:
 - Language: en
   Versions:
@@ -41,10 +50,13 @@ Languages:
     - ID: "1c75d8e4-860f-4a6f-86f5-e0868d0114f1"
       Hint: OGImage
       Value: |
-        <image mediaid="{0BE1CD1C-6448-4156-B8A5-548C81507908}" />
+        <image mediaid="{6DD6D8B3-0233-4D50-ABF9-115C6267F80C}" />
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
       Value: 20240125T170104Z
+    - ID: "425fc397-e978-435c-a532-439543cdd653"
+      Hint: Title
+      Value: Agenda
     - ID: "4e0720e9-9d50-4ddc-87cf-ecd65e8e94c8"
       Hint: NavigationTitle
       Value: Agenda
@@ -61,26 +73,23 @@ Languages:
       Value: website
     - ID: "7d817b40-bd80-41e3-8562-5ec5f3fb95fd"
       Hint: MetaDescription
-      Value: Join us at SUGCON ANZ 2023, the premier ANZ conference for Sitecore professionals. Learn from experts, network with peers, and explore the latest in Sitecore technology.
+      Value: Join us at SUGCON ANZ 2025, the premier ANZ conference for Sitecore professionals. Learn from experts, network with peers, and explore the latest in Sitecore technology.
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "1556112c-1754-4832-9107-49e92f9ba6fc"
+      Value: "650c231e-d16f-4ab3-a751-02e6d2c4dbb9"
     - ID: "b03cdc17-d7b5-4c87-97a9-b57352fe54a3"
       Hint: OGTitle
-      Value: SUGCON ANZ 2023 Agenda | The ANZ Sitecore User Group Conference
-    - ID: "b0c01040-9941-4a8f-8400-b274c377885e"
-      Hint: Title
-      Value: Agenda
+      Value: SUGCON ANZ 2025 Agenda | The ANZ Sitecore User Group Conference
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\sebastian.winter@sitecore.com
+        sitecore\Rob Earlam
     - ID: "cbb2a914-81e3-4fe6-8aed-deab8ed8b98e"
       Hint: OGDescription
-      Value: Explore the exciting lineup of speakers and sessions at SUGCON ANZ 2023. Discover the latest in Sitecore technology and connect with other professionals in the industry.
+      Value: Explore the exciting lineup of speakers and sessions at SUGCON ANZ 2025. Discover the latest in Sitecore technology and connect with other professionals in the industry.
     - ID: "d71d9097-062c-4781-bae9-d6658ab01ade"
       Hint: MetaKeywords
       Value: SUGCON, ANZ, Sitecore, User Group, Conference, Technology, Web Development, Digital Experience, CMS
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240424T130519Z
+      Value: 20250605T004222Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Home/Agenda/Data/Agenda EU.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Home/Agenda/Data/Agenda EU.yml
@@ -8,12 +8,15 @@ Languages:
   Versions:
   - Version: 1
     Fields:
+    - ID: "001dd393-96c5-490b-924a-b0f25cd9efd8"
+      Hint: __Lock
+      Value: <r />
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
       Value: 20240308T145509Z
     - ID: "32a8c629-0460-4070-a9f4-99f792bbbb92"
       Hint: SessionizeUrl
-      Value: "https://sessionize.com/api/v2/zoqj049r/view/GridSmart"
+      Value: "https://sessionize.com/api/v2/tm102qb2/view/GridSmart"
     - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
       Hint: __Owner
       Value: |
@@ -24,11 +27,11 @@ Languages:
         sitecore\sebastian.winter@sitecore.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "c5f1d137-5a36-448b-9c2b-34debffcabd0"
+      Value: "88ec77db-2c52-4c68-9261-8752871006e6"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\sebastian.winter@sitecore.com
+        sitecore\Rob Earlam
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240424T102234Z
+      Value: 20250604T235127Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Home/On-Demand.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Home/On-Demand.yml
@@ -1,7 +1,7 @@
 ﻿---
 ID: "93e1dc30-417b-47e9-884a-96cd343eec86"
 Parent: "104aab05-98db-4152-a2fe-95e7fc9a3c87"
-Template: "f5d59b30-223d-4e5a-967d-19daf7934db6"
+Template: "a094d215-ec24-4a11-a9c3-ef44c7cb7826"
 Path: "/sitecore/content/Sugcon2024/ANZ/Home/On-Demand"
 SharedFields:
 - ID: "1fbc6a49-6281-48ee-87e9-a3970b145adb"
@@ -10,13 +10,19 @@ SharedFields:
 - ID: "508c54c0-cd02-4266-8b68-d71f88de1aa9"
   Hint: ChangeFrequency
   Value: "{1C2878D9-80A6-4760-B7EB-DBADE16AE8C8}"
+- ID: "9135200a-5626-4dd8-ab9d-d665b8c11748"
+  Hint: __Never publish
+  Value: 1
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
   Value: 400
 - ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
   Hint: __Thumbnail
   Value: |
-    <image mediaid="{8139BF67-6AAF-4D22-AF59-E38904A4C6EC}" />
+    <image mediaid="{AB37C649-CBFE-4C6F-8AFB-4C3F8174662C}" />
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "334f3e90-4e46-4992-8139-b8ac93727323"
 Languages:
 - Language: en
   Versions:
@@ -25,6 +31,9 @@ Languages:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
       Value: 20240125T170413Z
+    - ID: "425fc397-e978-435c-a532-439543cdd653"
+      Hint: Title
+      Value: "On-Demand"
     - ID: "4e0720e9-9d50-4ddc-87cf-ecd65e8e94c8"
       Hint: NavigationTitle
       Value: "On-Demand"
@@ -38,14 +47,11 @@ Languages:
         sitecore\anna.bruendel@gmail.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "3d60557b-3e72-4b2e-b6f6-aeafd3593ef5"
-    - ID: "b0c01040-9941-4a8f-8400-b274c377885e"
-      Hint: Title
-      Value: "On-Demand"
+      Value: "00b27fc5-da7a-4f84-b91b-6defe5cd0660"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\sebastian.winter@sitecore.com
+        sitecore\Rob Earlam
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240424T101445Z
+      Value: 20250605T004237Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Home/Organizers.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Home/Organizers.yml
@@ -1,16 +1,19 @@
 ﻿---
 ID: "9dcf7c44-06f6-4bbc-a016-52e16ef57811"
 Parent: "104aab05-98db-4152-a2fe-95e7fc9a3c87"
-Template: "f5d59b30-223d-4e5a-967d-19daf7934db6"
+Template: "a094d215-ec24-4a11-a9c3-ef44c7cb7826"
 Path: /sitecore/content/Sugcon2024/ANZ/Home/Organizers
 SharedFields:
+- ID: "1fbc6a49-6281-48ee-87e9-a3970b145adb"
+  Hint: NavigationFilter
+  Value: 
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
   Value: 600
 - ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
   Hint: __Thumbnail
   Value: |
-    <image mediaid="{5E6BE2E8-CC1A-428F-9524-080F7EF6D794}" />
+    <image mediaid="{637332C7-5780-44E8-AB30-CBDB5FC394A6}" />
 Languages:
 - Language: en
   Versions:
@@ -42,10 +45,13 @@ Languages:
     - ID: "1c75d8e4-860f-4a6f-86f5-e0868d0114f1"
       Hint: OGImage
       Value: |
-        <image mediaid="{0BE1CD1C-6448-4156-B8A5-548C81507908}" />
+        <image mediaid="{6DD6D8B3-0233-4D50-ABF9-115C6267F80C}" />
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
       Value: 20240125T170401Z
+    - ID: "425fc397-e978-435c-a532-439543cdd653"
+      Hint: Title
+      Value: Organization Team
     - ID: "4e0720e9-9d50-4ddc-87cf-ecd65e8e94c8"
       Hint: NavigationTitle
       Value: Organizers
@@ -62,26 +68,23 @@ Languages:
       Value: website
     - ID: "7d817b40-bd80-41e3-8562-5ec5f3fb95fd"
       Hint: MetaDescription
-      Value: Meet the dedicated and experienced team behind SUGCON ANZ 2023. Learn about their passion for Sitecore and commitment to delivering a successful conference.
+      Value: Meet the dedicated and experienced team behind SUGCON ANZ 2025. Learn about their passion for Sitecore and commitment to delivering a successful conference.
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "f307154a-bff6-4aee-a801-814dd165e570"
+      Value: "c98418ae-f723-4304-884a-4a57449b442f"
     - ID: "b03cdc17-d7b5-4c87-97a9-b57352fe54a3"
       Hint: OGTitle
-      Value: SUGCON ANZ 2023 Organisation Team | The ANZ Sitecore User Group Conference
-    - ID: "b0c01040-9941-4a8f-8400-b274c377885e"
-      Hint: Title
-      Value: Organization Team
+      Value: SUGCON ANZ 2025 Organisation Team | The ANZ Sitecore User Group Conference
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\sebastian.winter@sitecore.com
+        sitecore\Rob Earlam
     - ID: "cbb2a914-81e3-4fe6-8aed-deab8ed8b98e"
       Hint: OGDescription
-      Value: Meet the dedicated and experienced team behind SUGCON ANZ 2023 Learn about their passion for Sitecore and commitment to delivering a successful conference.
+      Value: Meet the dedicated and experienced team behind SUGCON ANZ 2025 Learn about their passion for Sitecore and commitment to delivering a successful conference.
     - ID: "d71d9097-062c-4781-bae9-d6658ab01ade"
       Hint: MetaKeywords
       Value: SUGCON, ANZ, Sitecore, User Group, Conference, Organization Team, Dedicated, Experienced, Passion, Commitment, Successful
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240424T130824Z
+      Value: 20250605T004339Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Home/Sessions.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Home/Sessions.yml
@@ -1,16 +1,25 @@
 ﻿---
 ID: "30869058-648f-4251-8b57-407d9fa667eb"
 Parent: "104aab05-98db-4152-a2fe-95e7fc9a3c87"
-Template: "f5d59b30-223d-4e5a-967d-19daf7934db6"
+Template: "a094d215-ec24-4a11-a9c3-ef44c7cb7826"
 Path: /sitecore/content/Sugcon2024/ANZ/Home/Sessions
 SharedFields:
+- ID: "1fbc6a49-6281-48ee-87e9-a3970b145adb"
+  Hint: NavigationFilter
+  Value: "{D063E9D1-C7B5-4B1E-B31E-69886C9C59F5}"
+- ID: "9135200a-5626-4dd8-ab9d-d665b8c11748"
+  Hint: __Never publish
+  Value: 1
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
   Value: 500
 - ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
   Hint: __Thumbnail
   Value: |
-    <image mediaid="{385C7369-2ADA-4476-BBFF-82CBACEE7244}" />
+    <image mediaid="{C2EAA61E-0EE7-4286-AAC3-F0A3E93792B2}" />
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "4e23e5b2-07c0-42c6-9905-583449d3fd93"
 Languages:
 - Language: en
   Versions:
@@ -41,10 +50,13 @@ Languages:
     - ID: "1c75d8e4-860f-4a6f-86f5-e0868d0114f1"
       Hint: OGImage
       Value: |
-        <image mediaid="{0BE1CD1C-6448-4156-B8A5-548C81507908}" />
+        <image mediaid="{6DD6D8B3-0233-4D50-ABF9-115C6267F80C}" />
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
       Value: 20240125T170025Z
+    - ID: "425fc397-e978-435c-a532-439543cdd653"
+      Hint: Title
+      Value: Sessions
     - ID: "4e0720e9-9d50-4ddc-87cf-ecd65e8e94c8"
       Hint: NavigationTitle
       Value: Sessions
@@ -61,26 +73,23 @@ Languages:
       Value: website
     - ID: "7d817b40-bd80-41e3-8562-5ec5f3fb95fd"
       Hint: MetaDescription
-      Value: Explore the exciting and informative sessions at SUGCON ANZ 2023. Get insights into the latest trends and best practices in Sitecore.
+      Value: Explore the exciting and informative sessions at SUGCON ANZ 2025. Get insights into the latest trends and best practices in Sitecore.
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "0a60b861-3134-4cad-b6ef-024b18c72ee2"
+      Value: "7ffb864e-2b7b-4461-8414-b0f25fb25fbe"
     - ID: "b03cdc17-d7b5-4c87-97a9-b57352fe54a3"
       Hint: OGTitle
-      Value: SUGCON ANZ 2023 Sessions | The ANZ Sitecore User Group Conference
-    - ID: "b0c01040-9941-4a8f-8400-b274c377885e"
-      Hint: Title
-      Value: Sessions
+      Value: SUGCON ANZ 2025 Sessions | The ANZ Sitecore User Group Conference
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\sebastian.winter@sitecore.com
+        sitecore\Rob Earlam
     - ID: "cbb2a914-81e3-4fe6-8aed-deab8ed8b98e"
       Hint: OGDescription
-      Value: Explore the exciting and informative sessions at SUGCON ANZ 2023. Get insights into the latest trends and best practices in Sitecore.
+      Value: Explore the exciting and informative sessions at SUGCON ANZ 2025. Get insights into the latest trends and best practices in Sitecore.
     - ID: "d71d9097-062c-4781-bae9-d6658ab01ade"
       Hint: MetaKeywords
       Value: SUGCON, ANZ, Sitecore, User Group, Conference, Sessions, Trends, Best Practices, Insights
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240424T130722Z
+      Value: 20250605T004251Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Home/Speakers.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Home/Speakers.yml
@@ -1,16 +1,25 @@
 ﻿---
 ID: "5413d900-9147-4580-b5e8-ca2daf38f233"
 Parent: "104aab05-98db-4152-a2fe-95e7fc9a3c87"
-Template: "f5d59b30-223d-4e5a-967d-19daf7934db6"
+Template: "a094d215-ec24-4a11-a9c3-ef44c7cb7826"
 Path: /sitecore/content/Sugcon2024/ANZ/Home/Speakers
 SharedFields:
+- ID: "1fbc6a49-6281-48ee-87e9-a3970b145adb"
+  Hint: NavigationFilter
+  Value: "{D063E9D1-C7B5-4B1E-B31E-69886C9C59F5}"
+- ID: "9135200a-5626-4dd8-ab9d-d665b8c11748"
+  Hint: __Never publish
+  Value: 1
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
   Value: 550
 - ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
   Hint: __Thumbnail
   Value: |
-    <image mediaid="{9A08E182-438E-4002-96B7-BCFAB83806D8}" />
+    <image mediaid="{461AB591-7DC2-4358-8152-EC286FC50406}" />
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "1636f567-8285-4e0a-b2f1-ce0754253978"
 Languages:
 - Language: en
   Versions:
@@ -41,10 +50,13 @@ Languages:
     - ID: "1c75d8e4-860f-4a6f-86f5-e0868d0114f1"
       Hint: OGImage
       Value: |
-        <image mediaid="{0BE1CD1C-6448-4156-B8A5-548C81507908}" />
+        <image mediaid="{6DD6D8B3-0233-4D50-ABF9-115C6267F80C}" />
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
       Value: 20240125T170322Z
+    - ID: "425fc397-e978-435c-a532-439543cdd653"
+      Hint: Title
+      Value: Speakers
     - ID: "4e0720e9-9d50-4ddc-87cf-ecd65e8e94c8"
       Hint: NavigationTitle
       Value: Speakers
@@ -61,26 +73,23 @@ Languages:
       Value: website
     - ID: "7d817b40-bd80-41e3-8562-5ec5f3fb95fd"
       Hint: MetaDescription
-      Value: Meet the dynamic and knowledgeable speakers of SUGCON ANZ 2023. Learn from the experts and get inspired for your Sitecore journey.
+      Value: Meet the dynamic and knowledgeable speakers of SUGCON ANZ 2025. Learn from the experts and get inspired for your Sitecore journey.
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "10b3fb54-7211-41e0-8d6b-6039d20fbd6e"
+      Value: "afe773f8-6b10-4e1e-848c-06e4f51612fc"
     - ID: "b03cdc17-d7b5-4c87-97a9-b57352fe54a3"
       Hint: OGTitle
-      Value: SUGCON ANZ 2023 Speakers | The ANZ Sitecore User Group Conference
-    - ID: "b0c01040-9941-4a8f-8400-b274c377885e"
-      Hint: Title
-      Value: Speakers
+      Value: SUGCON ANZ 2025 Speakers | The ANZ Sitecore User Group Conference
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\sebastian.winter@sitecore.com
+        sitecore\Rob Earlam
     - ID: "cbb2a914-81e3-4fe6-8aed-deab8ed8b98e"
       Hint: OGDescription
-      Value: Meet the dynamic and knowledgeable speakers of SUGCON ANZ 2023. Learn from the experts and get inspired for your Sitecore journey.
+      Value: Meet the dynamic and knowledgeable speakers of SUGCON ANZ 2025. Learn from the experts and get inspired for your Sitecore journey.
     - ID: "d71d9097-062c-4781-bae9-d6658ab01ade"
       Hint: MetaKeywords
       Value: SUGCON, ANZ, Sitecore, User Group, Conference, Speakers, Experts, Inspiration, Journey
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240424T130643Z
+      Value: 20250605T004302Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Home/Speakers/Data/Speakers.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Home/Speakers/Data/Speakers.yml
@@ -27,14 +27,14 @@ Languages:
         sitecore\UOUBIWQRx7
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "6ca0dc99-6549-4530-9a8e-6b76fe61f5d5"
+      Value: "e29bc171-1aa5-4a4a-8232-0ab7d2e61400"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\sebastian.winter@sitecore.com
+        sitecore\Rob Earlam
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240424T102305Z
+      Value: 20250604T235257Z
     - ID: "f42c569e-47f1-4035-98b1-33077b15eae6"
       Hint: SessionizeSpeakerUrl
-      Value: "https://sessionize.com/api/v2/zoqj049r/view/Speakers"
+      Value: "https://sessionize.com/api/v2/tm102qb2/view/Speakers"

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Home/Sponsors.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Home/Sponsors.yml
@@ -1,16 +1,25 @@
 ﻿---
 ID: "868083e3-8677-4458-a07d-efe3f110085f"
 Parent: "104aab05-98db-4152-a2fe-95e7fc9a3c87"
-Template: "f5d59b30-223d-4e5a-967d-19daf7934db6"
+Template: "a094d215-ec24-4a11-a9c3-ef44c7cb7826"
 Path: /sitecore/content/Sugcon2024/ANZ/Home/Sponsors
 SharedFields:
+- ID: "1fbc6a49-6281-48ee-87e9-a3970b145adb"
+  Hint: NavigationFilter
+  Value: "{D063E9D1-C7B5-4B1E-B31E-69886C9C59F5}"
+- ID: "9135200a-5626-4dd8-ab9d-d665b8c11748"
+  Hint: __Never publish
+  Value: 1
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
   Value: 575
 - ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
   Hint: __Thumbnail
   Value: |
-    <image mediaid="{1591695B-47D3-416B-B9D9-68B576D5B20C}" />
+    <image mediaid="{74B5227A-A37A-4B8A-ABEC-3F626A5342E4}" />
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "76a65527-28ad-4619-9b86-9f4913fa8d2c"
 Languages:
 - Language: en
   Versions:
@@ -66,17 +75,20 @@ Languages:
               p:after="*[1=2]"
               s:ds="96c73333-de88-468b-84b8-34d73c0cf7f4"
               s:id="{25D85B6B-D6A8-411F-89A4-A99C0B8EEA39}"
-              s:par="GridParameters=%7B7465D855-992E-4DC2-9855-A03250DFA74B%7D&amp;FieldNames=%7B529C0C05-A39D-49EE-BF1B-49312841B17C%7D&amp;Styles&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=17"
+              s:par="GridParameters=%7B7465D855-992E-4DC2-9855-A03250DFA74B%7D&amp;FieldNames=%7BC12D2D95-DC36-4745-8442-65E630D6A6B3%7D&amp;Styles&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=17"
               s:ph="/headless-main/sxa-generic-page/container-2" />
           </d>
         </r>
     - ID: "1c75d8e4-860f-4a6f-86f5-e0868d0114f1"
       Hint: OGImage
       Value: |
-        <image mediaid="{0BE1CD1C-6448-4156-B8A5-548C81507908}" />
+        <image mediaid="{6DD6D8B3-0233-4D50-ABF9-115C6267F80C}" />
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
       Value: 20240125T170349Z
+    - ID: "425fc397-e978-435c-a532-439543cdd653"
+      Hint: Title
+      Value: Sponsors
     - ID: "4e0720e9-9d50-4ddc-87cf-ecd65e8e94c8"
       Hint: NavigationTitle
       Value: Sponsors
@@ -93,26 +105,23 @@ Languages:
       Value: website
     - ID: "7d817b40-bd80-41e3-8562-5ec5f3fb95fd"
       Hint: MetaDescription
-      Value: Join the leading companies and organizations supporting SUGCON ANZ 2023. Get recognition and exposure for your brand and services.
+      Value: Join the leading companies and organizations supporting SUGCON ANZ 2025. Get recognition and exposure for your brand and services.
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "65faab48-25c1-4b12-902e-2b241b7ee8ab"
+      Value: "e6c056c5-33fd-4a31-b132-01667b513ad6"
     - ID: "b03cdc17-d7b5-4c87-97a9-b57352fe54a3"
       Hint: OGTitle
-      Value: SUGCON ANZ 2023 Sponsors | The ANZ Sitecore User Group Conference
-    - ID: "b0c01040-9941-4a8f-8400-b274c377885e"
-      Hint: Title
-      Value: Sponsors
+      Value: SUGCON ANZ 2025 Sponsors | The ANZ Sitecore User Group Conference
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\sebastian.winter@sitecore.com
+        sitecore\Rob Earlam
     - ID: "cbb2a914-81e3-4fe6-8aed-deab8ed8b98e"
       Hint: OGDescription
-      Value: Join the leading companies and organizations supporting SUGCON ANZ 2023. Get recognition and exposure for your brand and services.
+      Value: Join the leading companies and organizations supporting SUGCON ANZ 2025. Get recognition and exposure for your brand and services.
     - ID: "d71d9097-062c-4781-bae9-d6658ab01ade"
       Hint: MetaKeywords
       Value: SUGCON, ANZ, Sitecore, User Group, Conference, Sponsors, Companies, Organizations, Recognition, Exposure, Brand, Services
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240424T130757Z
+      Value: 20250605T004325Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Home/Venue.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Home/Venue.yml
@@ -1,24 +1,36 @@
 ﻿---
 ID: "fdd2b465-56b3-4047-a1b1-1e71367d35d5"
 Parent: "104aab05-98db-4152-a2fe-95e7fc9a3c87"
-Template: "f5d59b30-223d-4e5a-967d-19daf7934db6"
+Template: "a094d215-ec24-4a11-a9c3-ef44c7cb7826"
 Path: /sitecore/content/Sugcon2024/ANZ/Home/Venue
 SharedFields:
 - ID: "1fbc6a49-6281-48ee-87e9-a3970b145adb"
   Hint: NavigationFilter
-  Value: "{D063E9D1-C7B5-4B1E-B31E-69886C9C59F5}"
+  Value: 
+- ID: "24171bf1-c0e1-480e-be76-4c0a1876f916"
+  Hint: Page Design
+  Value: 
 - ID: "508c54c0-cd02-4266-8b68-d71f88de1aa9"
   Hint: ChangeFrequency
   Value: "{1C2878D9-80A6-4760-B7EB-DBADE16AE8C8}"
+- ID: "9135200a-5626-4dd8-ab9d-d665b8c11748"
+  Hint: __Never publish
+  Value: 
 - ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
   Hint: __Thumbnail
   Value: |
-    <image mediaid="{1E0325CF-DDF9-41DF-A6DE-389BEA7468D6}" />
+    <image mediaid="{D6716BDB-1749-4EC6-8D6C-E3736B53F901}" />
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "7254d9c2-df91-45ad-a9f8-17e318b154a2"
 Languages:
 - Language: en
   Versions:
   - Version: 1
     Fields:
+    - ID: "001dd393-96c5-490b-924a-b0f25cd9efd8"
+      Hint: __Lock
+      Value: <r />
     - ID: "04bf00db-f5fb-41f7-8ab7-22408372a981"
       Hint: __Final Renderings
       Value: |
@@ -28,27 +40,22 @@ Languages:
             id="{FE5D7FDF-89C0-4D99-9AA3-B5FBD009C9F3}">
             <r
               uid="{A7250C08-16B5-48D3-A9F0-0048D87D75CA}"
-              p:before="*"
               s:ds="50D1D122-878A-4837-AF8E-B39C61487878"
               s:id="{4718D9E1-E2BC-4FDD-8305-4CBA3DF7466B}"
               s:par="GridParameters=%7B7465D855-992E-4DC2-9855-A03250DFA74B%7D&amp;FieldNames=%7BD2043589-BF58-4212-BDE7-80FDDCCE4B7D%7D&amp;Styles&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=1"
-              s:ph="/headless-main/sxa-generic-page/container-2" />
-            <r
-              uid="{24E3B759-DD7B-4D45-AA8E-45A3D4D97731}"
-              p:after="*[1=2]"
-              s:ds="2F64F648-90ED-40F4-891A-0BD9DA88ECF7"
-              s:id="{AB87F73E-6532-41CD-8234-D0E40DE84D90}"
-              s:par="GridParameters=%7B7465D855-992E-4DC2-9855-A03250DFA74B%7D&amp;FieldNames&amp;Styles&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=4"
               s:ph="/headless-main/sxa-generic-page/container-2" />
           </d>
         </r>
     - ID: "1c75d8e4-860f-4a6f-86f5-e0868d0114f1"
       Hint: OGImage
       Value: |
-        <image mediaid="{B83A6684-B680-4001-AA6C-72661A01888D}" />
+        <image mediaid="{6DD6D8B3-0233-4D50-ABF9-115C6267F80C}" />
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
       Value: 20240403T063659Z
+    - ID: "425fc397-e978-435c-a532-439543cdd653"
+      Hint: Title
+      Value: Venue
     - ID: "4e0720e9-9d50-4ddc-87cf-ecd65e8e94c8"
       Hint: NavigationTitle
       Value: Venue
@@ -65,26 +72,23 @@ Languages:
       Value: website
     - ID: "7d817b40-bd80-41e3-8562-5ec5f3fb95fd"
       Hint: MetaDescription
-      Value: Discover the stunning venue for SUGCON Europe 2024. Explore the city, connect with attendees, and get ready for an unforgettable experience.
+      Value: Discover the stunning venue for SUGCON ANZ 2025. Explore the city, connect with attendees, and get ready for an unforgettable experience.
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "8d1f3141-18f3-4a6a-baf3-90d4ac8d16ed"
+      Value: "ba92b1b6-57b0-495b-be9c-c06d05835f7b"
     - ID: "b03cdc17-d7b5-4c87-97a9-b57352fe54a3"
       Hint: OGTitle
-      Value: Europe 2024 Venue | The European Sitecore User Group Conference
-    - ID: "b0c01040-9941-4a8f-8400-b274c377885e"
-      Hint: Title
-      Value: Venue
+      Value: SUGCON ANZ 2025 Venue | The European Sitecore User Group Conference
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\sebastian.winter@sitecore.com
+        sitecore\Rob Earlam
     - ID: "cbb2a914-81e3-4fe6-8aed-deab8ed8b98e"
       Hint: OGDescription
-      Value: Discover the stunning venue for SUGCON Europe 2024. Explore the city, connect with attendees, and get ready for an unforgettable experience.
+      Value: Discover the stunning venue for SUGCON ANZ 2025. Explore the city, connect with attendees, and get ready for an unforgettable experience.
     - ID: "d71d9097-062c-4781-bae9-d6658ab01ade"
       Hint: MetaKeywords
       Value: SUGCON, Europe, Sitecore, User Group, Conference, Venue, City, Experience, Networking
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240424T101436Z
+      Value: 20250605T003628Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Home/Workshops.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Home/Workshops.yml
@@ -1,7 +1,7 @@
 ﻿---
 ID: "e617991c-b32f-43d1-b0f7-fb511131061e"
 Parent: "104aab05-98db-4152-a2fe-95e7fc9a3c87"
-Template: "f5d59b30-223d-4e5a-967d-19daf7934db6"
+Template: "a094d215-ec24-4a11-a9c3-ef44c7cb7826"
 Path: /sitecore/content/Sugcon2024/ANZ/Home/Workshops
 SharedFields:
 - ID: "1fbc6a49-6281-48ee-87e9-a3970b145adb"
@@ -10,13 +10,19 @@ SharedFields:
 - ID: "508c54c0-cd02-4266-8b68-d71f88de1aa9"
   Hint: ChangeFrequency
   Value: "{1C2878D9-80A6-4760-B7EB-DBADE16AE8C8}"
+- ID: "9135200a-5626-4dd8-ab9d-d665b8c11748"
+  Hint: __Never publish
+  Value: 1
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
   Value: 563
 - ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
   Hint: __Thumbnail
   Value: |
-    <image mediaid="{35F7853F-9182-44DD-92E4-A89F12009B63}" />
+    <image mediaid="{D5D0A941-85E7-465D-BDB0-10C52553B262}" />
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "87db14bd-63ac-47ee-9d8f-577b67b33a19"
 Languages:
 - Language: en
   Versions:
@@ -48,10 +54,13 @@ Languages:
     - ID: "1c75d8e4-860f-4a6f-86f5-e0868d0114f1"
       Hint: OGImage
       Value: |
-        <image mediaid="{B83A6684-B680-4001-AA6C-72661A01888D}" />
+        <image mediaid="{6DD6D8B3-0233-4D50-ABF9-115C6267F80C}" />
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
       Value: 20240125T170333Z
+    - ID: "425fc397-e978-435c-a532-439543cdd653"
+      Hint: Title
+      Value: Workshops  and Certifications
     - ID: "4e0720e9-9d50-4ddc-87cf-ecd65e8e94c8"
       Hint: NavigationTitle
       Value: Workshops
@@ -71,17 +80,14 @@ Languages:
       Value: Sign up for a complimentary XM Cloud workshop to help you take your Sitecore skills to the next level. Get certified.
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "01568d1f-dc77-43a8-99b5-1ae1194a0041"
+      Value: "bacfcb6c-b4a4-4d8c-bb06-45087aa81f05"
     - ID: "b03cdc17-d7b5-4c87-97a9-b57352fe54a3"
       Hint: OGTitle
-      Value: SUGCON Europe 2024 Workshops  and Certifications | The European Sitecore User Group Conference
-    - ID: "b0c01040-9941-4a8f-8400-b274c377885e"
-      Hint: Title
-      Value: Workshops  and Certifications
+      Value: SUGCON ANZ 2025 Workshops  and Certifications | The European Sitecore User Group Conference
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\sebastian.winter@sitecore.com
+        sitecore\Rob Earlam
     - ID: "cbb2a914-81e3-4fe6-8aed-deab8ed8b98e"
       Hint: OGDescription
       Value: Sign up for a complimentary XM Cloud workshop to help you take your Sitecore skills to the next level. Get certified.
@@ -90,4 +96,4 @@ Languages:
       Value: SUGCON, Europe, Sitecore, User Group, Conference, Certification, Workshop, Best Practices, XM Cloud, Developer
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240424T101459Z
+      Value: 20250605T004312Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Presentation/Page Designs.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Presentation/Page Designs.yml
@@ -7,7 +7,10 @@ BranchID: "45cf9f42-b3ac-4412-aab9-f8441c7e448e"
 SharedFields:
 - ID: "ba1f60d6-3deb-40cc-bb61-eec772279ee1"
   Hint: TemplatesMapping
-  Value: "%7bF5D59B30-223D-4E5A-967D-19DAF7934DB6%7d%3d%257BAE6A7C57-1307-41C0-A613-949F33266DE4%257D%26%7b28F60DA7-21F8-4791-9ECF-F65A93E105A4%7d%3d%257B47B6EA94-7583-4582-B014-9DFEC2C93583%257D"
+  Value: "%7bF5D59B30-223D-4E5A-967D-19DAF7934DB6%7d%3d%257BAE6A7C57-1307-41C0-A613-949F33266DE4%257D%26%7b28F60DA7-21F8-4791-9ECF-F65A93E105A4%7d%3d%257B47B6EA94-7583-4582-B014-9DFEC2C93583%257D%26%7bA094D215-EC24-4A11-A9C3-EF44C7CB7826%7d%3d%257B73E323E9-0F5B-4355-89F3-03466952D319%257D%26%7bF73D4C6D-F7E5-4E9F-838B-F60ABB54A4C2%7d%3d%257B0D35B12E-DFB3-4280-8964-AEF329475B45%257D"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "8ede552c-74ca-4705-b797-a1f4b61c1cd8"
 - ID: "f6d8a61c-2f84-4401-bd24-52d2068172bc"
   Hint: __Originator
   Value: "{2EA756FA-AED6-4599-83B7-36FEFE229B31}"
@@ -29,11 +32,11 @@ Languages:
         sitecore\sebastian.winter@sitecore.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "6e383da8-b2c7-45dd-9c66-74ca30347fd3"
+      Value: "02d3b818-fbd0-4b6b-9c9c-c3c27e085cd4"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\sebastian.winter@sitecore.com
+        sitecore\Rob Earlam
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240207T122433Z
+      Value: 20250605T004119Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Presentation/Page Designs/ANZ Generic Page.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Presentation/Page Designs/ANZ Generic Page.yml
@@ -1,0 +1,42 @@
+﻿---
+ID: "73e323e9-0f5b-4355-89f3-03466952d319"
+Parent: "3ff247e7-70c0-429a-a836-374916f7c2b1"
+Template: "1105b8f8-1e00-426b-bf1f-c840742d827b"
+Path: /sitecore/content/Sugcon2024/ANZ/Presentation/Page Designs/ANZ Generic Page
+SharedFields:
+- ID: "0966b999-0d0e-4278-acc9-9da69d461fe6"
+  Hint: PartialDesigns
+  Value: "61bd65ce-5270-4961-a1cd-9f0263dc662a|4a792e35-39c9-488a-a0e8-24aacb84e23a|80bd8fe8-6e7f-41b6-9d5a-11394a4229e3"
+- ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
+  Hint: __Thumbnail
+  Value: |
+    <image mediaid="{60C8590F-31BF-4688-978D-6B61922E826B}" />
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "156ab52f-dede-4762-84ea-5cf80560be90"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250605T000918Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\Rob Earlam
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\Rob Earlam
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "3a1b75db-9b4e-4613-af5d-51f6a146eb69"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\Rob Earlam
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250605T001025Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Presentation/Page Designs/ANZ HomePage.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Presentation/Page Designs/ANZ HomePage.yml
@@ -1,0 +1,42 @@
+﻿---
+ID: "0d35b12e-dfb3-4280-8964-aef329475b45"
+Parent: "3ff247e7-70c0-429a-a836-374916f7c2b1"
+Template: "1105b8f8-1e00-426b-bf1f-c840742d827b"
+Path: /sitecore/content/Sugcon2024/ANZ/Presentation/Page Designs/ANZ HomePage
+SharedFields:
+- ID: "0966b999-0d0e-4278-acc9-9da69d461fe6"
+  Hint: PartialDesigns
+  Value: "{80BD8FE8-6E7F-41B6-9D5A-11394A4229E3}|{61BD65CE-5270-4961-A1CD-9F0263DC662A}"
+- ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
+  Hint: __Thumbnail
+  Value: |
+    <image mediaid="{65F74876-B838-4AC1-8A9D-58C1F4DDB070}" />
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "ae3b92e7-275b-4a2b-971f-ad84e5cd4a69"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20240123T184248Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\UOUBIWQRx7
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\UOUBIWQRx7
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "be62a995-e84c-416f-a946-0a31d91c965e"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\Rob Earlam
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250605T004038Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Presentation/Partial Designs/ANZ Header.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Presentation/Partial Designs/ANZ Header.yml
@@ -1,0 +1,73 @@
+﻿---
+ID: "61bd65ce-5270-4961-a1cd-9f0263dc662a"
+Parent: "a9d7bf0b-6e64-4879-8fbc-bce02d899a09"
+Template: "fd2059fd-6043-4dfe-8c04-e2437ce87634"
+Path: /sitecore/content/Sugcon2024/ANZ/Presentation/Partial Designs/ANZ Header
+SharedFields:
+- ID: "55faae90-3bba-4f7f-96fe-13c3f40055ff"
+  Hint: Signature
+  Value: "anz-header"
+- ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
+  Hint: __Thumbnail
+  Value: |
+    <image mediaid="{F27703A9-D21F-4BF8-853C-CB294F78B325}" />
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "ec112948-7b2f-4de6-80c5-54d281b2c0bc"
+- ID: "f1a1fe9e-a60c-4ddb-a3a0-bb5b29fe732e"
+  Hint: __Renderings
+  Value: |
+    <r xmlns:p="p" xmlns:s="s"
+      p:p="1">
+      <d
+        id="{FE5D7FDF-89C0-4D99-9AA3-B5FBD009C9F3}">
+        <r
+          uid="{C123A7F7-7187-464C-82AB-BC343CD151F2}"
+          p:before="*"
+          s:ds="query:$site/Data/Images/Logos/Header"
+          s:id="{83D0E443-F5BB-4140-8152-BE180E05A225}"
+          s:par="GridParameters&amp;FieldNames&amp;Styles&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=1"
+          s:ph="headless-header"
+          s:ccb="Clear on publish" />
+        <r
+          uid="{C121B676-B3D6-4DFE-86CB-D98B939A2189}"
+          p:after="r[@uid='{C123A7F7-7187-464C-82AB-BC343CD151F2}']"
+          s:ds=""
+          s:id="{B1D977D1-85B6-489B-8AD5-24F32FF63F97}"
+          s:par="GridParameters=%7B7465D855-992E-4DC2-9855-A03250DFA74B%7D&amp;FieldNames=%7BC6BA2BCB-25E4-4F9E-B98D-65FB74F28335%7D&amp;Styles=%7B73830EF3-2D6D-449C-A174-EBA98EB7DC81%7D&amp;NavigationRoot&amp;LevelFrom=%7B1BB88840-5FB3-4353-AD8D-81136F6FF75A%7D&amp;LevelTo=%7BA59325BB-5A27-46F9-8110-9D499715F3BE%7D&amp;Filter=%7BD063E9D1-C7B5-4B1E-B31E-69886C9C59F5%7D&amp;Flattened&amp;AddRoot&amp;SerializerFieldNames&amp;RenderingIdentifier&amp;CSSStyles"
+          s:ph="headless-header" />
+        <r
+          uid="{4AC045CD-1F9D-4DB7-9711-76096ACA6E80}"
+          p:after="*[1=2]"
+          s:ds="{B7214CC6-C1E5-48AA-A227-D1B8A5013D00}"
+          s:id="{55493A56-C60D-44D2-8E5D-BAEFC399938E}"
+          s:par="GridParameters&amp;FieldNames=%7B338D9B47-AC81-404A-A470-752675BDE609%7D&amp;Styles&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=3"
+          s:ph="/headless-header/button-link-{C121B676-B3D6-4DFE-86CB-D98B939A2189}-0" />
+      </d>
+    </r>
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20240123T184027Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\UOUBIWQRx7
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\UOUBIWQRx7
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "3dede421-f272-4d5d-84af-9d510b240f56"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\Rob Earlam
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250605T010403Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Presentation/Placeholder Settings/Partial Design/ANZ Header.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/SiteANZ/ANZ/Presentation/Placeholder Settings/Partial Design/ANZ Header.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "3b15802d-716f-4b04-a0cc-1ca8ca189976"
+Parent: "fd621d47-244c-47c0-a9a9-770d63171842"
+Template: "d2a6884c-04d5-4089-a64e-d27ca9d68d4c"
+Path: /sitecore/content/Sugcon2024/ANZ/Presentation/Placeholder Settings/Partial Design/ANZ Header
+SharedFields:
+- ID: "7256bdab-1fd2-49dd-b205-cb4873d2917c"
+  Hint: Placeholder Key
+  Value: "sxa-anz-header"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "4fbcc84c-03bc-4741-a4c1-73e109b9fd30"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250605T000959Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\Rob Earlam
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\Rob Earlam
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "a4f0b98c-5379-4482-abcc-396017778c3a"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\Rob Earlam
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250605T010403Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/Templates/Sugcon2024/Page Templates/ANZ Generic Page.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/Templates/Sugcon2024/Page Templates/ANZ Generic Page.yml
@@ -1,0 +1,44 @@
+﻿---
+ID: "a094d215-ec24-4a11-a9c3-ef44c7cb7826"
+Parent: "146849cf-b4c7-4b24-b4f3-1d2483710f56"
+Template: "ab86861a-6030-46c5-b394-e8f99e8b87db"
+Path: /sitecore/templates/Project/Sugcon2024/Page Templates/ANZ Generic Page
+SharedFields:
+- ID: "06d5295c-ed2f-4a54-9bf2-26228d113318"
+  Hint: __Icon
+  Value: Office/32x32/document_text.png
+- ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
+  Hint: __Base template
+  Value: "{6A1B5FE6-5F3D-49FB-AC10-1F925C67E105}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "5bd6306e-91a4-42a3-8a6b-20794e5798c3"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{E87829BC-4A7C-4EE2-9D76-25F6ED180385}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20240105T121329Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\sebastian.winter@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\sebastian.winter@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "21de4830-2b8d-44a6-a6c1-eb89292c3a33"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\Rob Earlam
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250605T002346Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/Templates/Sugcon2024/Page Templates/ANZ Generic Page/Content.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/Templates/Sugcon2024/Page Templates/ANZ Generic Page/Content.yml
@@ -1,19 +1,16 @@
 ﻿---
-ID: "a04cecd0-b9f7-4a68-997e-192fb9e818ff"
-Parent: "0a2349dc-7fb8-4c30-84c6-4fe50433782f"
-Template: "c4c677b6-212b-44a4-aab4-67fcd082e5d8"
-Path: /sitecore/content/Sugcon2024/ANZ/Home/Sessions/Data/Sessions
+ID: "c9b3dc33-1807-4768-9f16-e74dbc60e00b"
+Parent: "a094d215-ec24-4a11-a9c3-ef44c7cb7826"
+Template: "e269fbb5-3750-427a-9149-7aa950b49301"
+Path: /sitecore/templates/Project/Sugcon2024/Page Templates/ANZ Generic Page/Content
 Languages:
 - Language: en
   Versions:
   - Version: 1
     Fields:
-    - ID: "1939738b-99b1-473d-9827-f0f321dc8980"
-      Hint: SessionizeUrl
-      Value: "https://sessionize.com/api/v2/tm102qb2/view/Sessions"
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
-      Value: 20240313T143147Z
+      Value: 20240105T121333Z
     - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
       Hint: __Owner
       Value: |
@@ -24,11 +21,11 @@ Languages:
         sitecore\sebastian.winter@sitecore.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "ab772456-bc15-4620-a299-d2a03f5c0b37"
+      Value: "dc712047-e4af-4489-8c93-fbafbb7ea632"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
         sitecore\Rob Earlam
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250604T235238Z
+      Value: 20250605T002346Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/Templates/Sugcon2024/Page Templates/ANZ Generic Page/Content/Content.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/Templates/Sugcon2024/Page Templates/ANZ Generic Page/Content/Content.yml
@@ -1,19 +1,26 @@
 ﻿---
-ID: "a04cecd0-b9f7-4a68-997e-192fb9e818ff"
-Parent: "0a2349dc-7fb8-4c30-84c6-4fe50433782f"
-Template: "c4c677b6-212b-44a4-aab4-67fcd082e5d8"
-Path: /sitecore/content/Sugcon2024/ANZ/Home/Sessions/Data/Sessions
+ID: "0027ca44-e707-4163-bbc3-0c73692bda88"
+Parent: "c9b3dc33-1807-4768-9f16-e74dbc60e00b"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Project/Sugcon2024/Page Templates/ANZ Generic Page/Content/Content
+SharedFields:
+- ID: "1eb8ae32-e190-44a6-968d-ed904c794ebf"
+  Hint: Source
+  Value: "query:$xaRichTextProfile"
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: Rich Text
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 2
 Languages:
 - Language: en
   Versions:
   - Version: 1
     Fields:
-    - ID: "1939738b-99b1-473d-9827-f0f321dc8980"
-      Hint: SessionizeUrl
-      Value: "https://sessionize.com/api/v2/tm102qb2/view/Sessions"
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
-      Value: 20240313T143147Z
+      Value: 20240105T121334Z
     - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
       Hint: __Owner
       Value: |
@@ -24,11 +31,11 @@ Languages:
         sitecore\sebastian.winter@sitecore.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "ab772456-bc15-4620-a299-d2a03f5c0b37"
+      Value: "86c6f5ef-0953-4b0b-a07c-da6ab4b91c4b"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
         sitecore\Rob Earlam
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250604T235238Z
+      Value: 20250605T002346Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/Templates/Sugcon2024/Page Templates/ANZ Generic Page/Content/Title.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/Templates/Sugcon2024/Page Templates/ANZ Generic Page/Content/Title.yml
@@ -1,19 +1,23 @@
 ﻿---
-ID: "a04cecd0-b9f7-4a68-997e-192fb9e818ff"
-Parent: "0a2349dc-7fb8-4c30-84c6-4fe50433782f"
-Template: "c4c677b6-212b-44a4-aab4-67fcd082e5d8"
-Path: /sitecore/content/Sugcon2024/ANZ/Home/Sessions/Data/Sessions
+ID: "425fc397-e978-435c-a532-439543cdd653"
+Parent: "c9b3dc33-1807-4768-9f16-e74dbc60e00b"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Project/Sugcon2024/Page Templates/ANZ Generic Page/Content/Title
+SharedFields:
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: "Single-Line Text"
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 1
 Languages:
 - Language: en
   Versions:
   - Version: 1
     Fields:
-    - ID: "1939738b-99b1-473d-9827-f0f321dc8980"
-      Hint: SessionizeUrl
-      Value: "https://sessionize.com/api/v2/tm102qb2/view/Sessions"
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
-      Value: 20240313T143147Z
+      Value: 20240105T121333Z
     - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
       Hint: __Owner
       Value: |
@@ -24,11 +28,11 @@ Languages:
         sitecore\sebastian.winter@sitecore.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "ab772456-bc15-4620-a299-d2a03f5c0b37"
+      Value: "ff2c17df-ae6a-49f6-abb7-7fff44cc99e8"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
         sitecore\Rob Earlam
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250604T235238Z
+      Value: 20250605T002346Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/Templates/Sugcon2024/Page Templates/ANZ Generic Page/__Standard Values.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/Templates/Sugcon2024/Page Templates/ANZ Generic Page/__Standard Values.yml
@@ -1,0 +1,44 @@
+﻿---
+ID: "e87829bc-4a7c-4ee2-9d76-25f6ed180385"
+Parent: "a094d215-ec24-4a11-a9c3-ef44c7cb7826"
+Template: "a094d215-ec24-4a11-a9c3-ef44c7cb7826"
+Path: /sitecore/templates/Project/Sugcon2024/Page Templates/ANZ Generic Page/__Standard Values
+SharedFields:
+- ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
+  Hint: __Masters
+  Value: |
+    {C14B6289-8AC2-439C-9E5B-40DE9F820C3F}
+    {A87A00B1-E6DB-45AB-8B54-636FEC3B5523}
+    {A094D215-EC24-4A11-A9C3-EF44C7CB7826}
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "8131764a-e6c6-4d75-8550-9eb72f53f3d0"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20240105T121329Z
+    - ID: "425fc397-e978-435c-a532-439543cdd653"
+      Hint: Title
+      Value: $name
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\sebastian.winter@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\sebastian.winter@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "c7229cd9-5f5f-4fdb-a570-3c5c7f941846"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\Rob Earlam
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250605T003910Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/Templates/Sugcon2024/Page Templates/ANZ Home Page.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/Templates/Sugcon2024/Page Templates/ANZ Home Page.yml
@@ -1,0 +1,44 @@
+﻿---
+ID: "f73d4c6d-f7e5-4e9f-838b-f60abb54a4c2"
+Parent: "146849cf-b4c7-4b24-b4f3-1d2483710f56"
+Template: "ab86861a-6030-46c5-b394-e8f99e8b87db"
+Path: /sitecore/templates/Project/Sugcon2024/Page Templates/ANZ Home Page
+SharedFields:
+- ID: "06d5295c-ed2f-4a54-9bf2-26228d113318"
+  Hint: __Icon
+  Value: office/32x32/home.png
+- ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
+  Hint: __Base template
+  Value: "{6A1B5FE6-5F3D-49FB-AC10-1F925C67E105}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "544321bd-80b8-4989-a28c-312128820a3e"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{C67D3A24-E584-46DB-BD2C-20CEDE54C5B0}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20240105T121329Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\sebastian.winter@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\sebastian.winter@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "3f4c26f8-2260-44c0-a8f8-34319494c9ae"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\Rob Earlam
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250605T003835Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/Templates/Sugcon2024/Page Templates/ANZ Home Page/Content.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/Templates/Sugcon2024/Page Templates/ANZ Home Page/Content.yml
@@ -1,19 +1,16 @@
 ﻿---
-ID: "a04cecd0-b9f7-4a68-997e-192fb9e818ff"
-Parent: "0a2349dc-7fb8-4c30-84c6-4fe50433782f"
-Template: "c4c677b6-212b-44a4-aab4-67fcd082e5d8"
-Path: /sitecore/content/Sugcon2024/ANZ/Home/Sessions/Data/Sessions
+ID: "75cf1a0c-4868-4c1d-b7bd-14a3b4febe27"
+Parent: "f73d4c6d-f7e5-4e9f-838b-f60abb54a4c2"
+Template: "e269fbb5-3750-427a-9149-7aa950b49301"
+Path: /sitecore/templates/Project/Sugcon2024/Page Templates/ANZ Home Page/Content
 Languages:
 - Language: en
   Versions:
   - Version: 1
     Fields:
-    - ID: "1939738b-99b1-473d-9827-f0f321dc8980"
-      Hint: SessionizeUrl
-      Value: "https://sessionize.com/api/v2/tm102qb2/view/Sessions"
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
-      Value: 20240313T143147Z
+      Value: 20240105T121333Z
     - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
       Hint: __Owner
       Value: |
@@ -24,11 +21,11 @@ Languages:
         sitecore\sebastian.winter@sitecore.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "ab772456-bc15-4620-a299-d2a03f5c0b37"
+      Value: "439d4895-fea6-4b3a-a615-ef1b71fb79ca"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Rob Earlam
+        sitecore\UOUBIWQRx7
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250604T235238Z
+      Value: 20240402T171626Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/Templates/Sugcon2024/Page Templates/ANZ Home Page/Content/Content.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/Templates/Sugcon2024/Page Templates/ANZ Home Page/Content/Content.yml
@@ -1,19 +1,26 @@
 ﻿---
-ID: "a04cecd0-b9f7-4a68-997e-192fb9e818ff"
-Parent: "0a2349dc-7fb8-4c30-84c6-4fe50433782f"
-Template: "c4c677b6-212b-44a4-aab4-67fcd082e5d8"
-Path: /sitecore/content/Sugcon2024/ANZ/Home/Sessions/Data/Sessions
+ID: "70b21b93-e3b7-4302-a091-43bd1ef43a5e"
+Parent: "75cf1a0c-4868-4c1d-b7bd-14a3b4febe27"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Project/Sugcon2024/Page Templates/ANZ Home Page/Content/Content
+SharedFields:
+- ID: "1eb8ae32-e190-44a6-968d-ed904c794ebf"
+  Hint: Source
+  Value: "query:$xaRichTextProfile"
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: Rich Text
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 2
 Languages:
 - Language: en
   Versions:
   - Version: 1
     Fields:
-    - ID: "1939738b-99b1-473d-9827-f0f321dc8980"
-      Hint: SessionizeUrl
-      Value: "https://sessionize.com/api/v2/tm102qb2/view/Sessions"
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
-      Value: 20240313T143147Z
+      Value: 20240105T121334Z
     - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
       Hint: __Owner
       Value: |
@@ -24,11 +31,11 @@ Languages:
         sitecore\sebastian.winter@sitecore.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "ab772456-bc15-4620-a299-d2a03f5c0b37"
+      Value: "399f832e-92ba-40c9-a636-653fb5f9a4d6"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Rob Earlam
+        sitecore\UOUBIWQRx7
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250604T235238Z
+      Value: 20240402T171626Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/Templates/Sugcon2024/Page Templates/ANZ Home Page/Content/Title.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/Templates/Sugcon2024/Page Templates/ANZ Home Page/Content/Title.yml
@@ -1,19 +1,23 @@
 ﻿---
-ID: "a04cecd0-b9f7-4a68-997e-192fb9e818ff"
-Parent: "0a2349dc-7fb8-4c30-84c6-4fe50433782f"
-Template: "c4c677b6-212b-44a4-aab4-67fcd082e5d8"
-Path: /sitecore/content/Sugcon2024/ANZ/Home/Sessions/Data/Sessions
+ID: "dac03f58-2882-4106-aada-b35f653537a6"
+Parent: "75cf1a0c-4868-4c1d-b7bd-14a3b4febe27"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Project/Sugcon2024/Page Templates/ANZ Home Page/Content/Title
+SharedFields:
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: "Single-Line Text"
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 1
 Languages:
 - Language: en
   Versions:
   - Version: 1
     Fields:
-    - ID: "1939738b-99b1-473d-9827-f0f321dc8980"
-      Hint: SessionizeUrl
-      Value: "https://sessionize.com/api/v2/tm102qb2/view/Sessions"
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
-      Value: 20240313T143147Z
+      Value: 20240105T121333Z
     - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
       Hint: __Owner
       Value: |
@@ -24,11 +28,11 @@ Languages:
         sitecore\sebastian.winter@sitecore.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "ab772456-bc15-4620-a299-d2a03f5c0b37"
+      Value: "05caad01-9c80-4921-80e9-6137d5ef1c02"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Rob Earlam
+        sitecore\UOUBIWQRx7
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250604T235238Z
+      Value: 20240402T171626Z

--- a/authoring/items/Sugcon2024/Sugcon/Sugcon/Templates/Sugcon2024/Page Templates/ANZ Home Page/__Standard Values.yml
+++ b/authoring/items/Sugcon2024/Sugcon/Sugcon/Templates/Sugcon2024/Page Templates/ANZ Home Page/__Standard Values.yml
@@ -1,19 +1,22 @@
 ﻿---
-ID: "a04cecd0-b9f7-4a68-997e-192fb9e818ff"
-Parent: "0a2349dc-7fb8-4c30-84c6-4fe50433782f"
-Template: "c4c677b6-212b-44a4-aab4-67fcd082e5d8"
-Path: /sitecore/content/Sugcon2024/ANZ/Home/Sessions/Data/Sessions
+ID: "c67d3a24-e584-46db-bd2c-20cede54c5b0"
+Parent: "f73d4c6d-f7e5-4e9f-838b-f60abb54a4c2"
+Template: "f73d4c6d-f7e5-4e9f-838b-f60abb54a4c2"
+Path: /sitecore/templates/Project/Sugcon2024/Page Templates/ANZ Home Page/__Standard Values
+SharedFields:
+- ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
+  Hint: __Masters
+  Value: |
+    {F5D59B30-223D-4E5A-967D-19DAF7934DB6}
+    {C14B6289-8AC2-439C-9E5B-40DE9F820C3F}
 Languages:
 - Language: en
   Versions:
   - Version: 1
     Fields:
-    - ID: "1939738b-99b1-473d-9827-f0f321dc8980"
-      Hint: SessionizeUrl
-      Value: "https://sessionize.com/api/v2/tm102qb2/view/Sessions"
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
-      Value: 20240313T143147Z
+      Value: 20240105T121329Z
     - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
       Hint: __Owner
       Value: |
@@ -24,11 +27,14 @@ Languages:
         sitecore\sebastian.winter@sitecore.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "ab772456-bc15-4620-a299-d2a03f5c0b37"
+      Value: "d0775ca1-e39a-4d35-9935-03b865ca5d9d"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
         sitecore\Rob Earlam
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250604T235238Z
+      Value: 20250605T003835Z
+    - ID: "dac03f58-2882-4106-aada-b35f653537a6"
+      Hint: Title
+      Value: $name


### PR DESCRIPTION
Attempt to fix menu caching issue, by changing the ANZ site to use its own dedicated header partial, and site specific page designs.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.