### PR TITLE
Added reset filter button option to clear the MVP Directory search fi…

### DIFF
--- a/headapps/MvpSite/MvpSite.Rendering/Views/Shared/Components/Directory/Default.cshtml
+++ b/headapps/MvpSite/MvpSite.Rendering/Views/Shared/Components/Directory/Default.cshtml
@@ -17,6 +17,8 @@
                         <button type="submit" class="btn btn-primary">
                             <i class="fa fa-search text-white" aria-hidden="true"></i>
                         </button>
+                        <a asp-for="DirectoryLink"
+                            class="btn btn-primary ml-2 d-flex align-items-center justify-content-center"></a>
                     </div>
                 </div>
                 <div class="results sc-gradient-light-bg extended-background">


### PR DESCRIPTION
…eld and filters

Users had to manually delete the search term and clear each filter individually, which was inefficient and frustrating.

## Description / Motivation

I added a "Reset" button (styled to match the existing UI) that performs the following actions when clicked:

Clears the search input field.
Resets all selected filters in one go.
Triggers a fresh search with default parameters (i.e., no filters or search terms).
https://github.com/Sitecore/XM-Cloud-Introduction/issues/526#issue-3076096727

## How Has This Been Tested?

To ensure the fix worked correctly, I performed the following tests:

**Functional Testing:**
Verified that clicking the reset button clears the search field.
Confirmed that all filters are deselected.
Ensured a new search is triggered with default parameters.

**UI/UX Testing:**
Checked that the button is visually consistent with the design system.
Ensured the button is accessible and responsive across screen sizes.

**Edge Case Testing:**
Tested with multiple filters selected and a long search term.
Verified behavior when no filters or search terms were set.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.

Fixes #526