### PR TITLE
fix #349: Remove Twitter as profile image source option due to API restrictions

### DIFF
--- a/headapps/MvpSite/MvpSite.Rendering/ViewComponents/Any/MyDataEditViewComponent.cs
+++ b/headapps/MvpSite/MvpSite.Rendering/ViewComponents/Any/MyDataEditViewComponent.cs
@@ -96,6 +96,6 @@ public class MyDataEditViewComponent(IViewModelBinder modelBinder, MvpSelections
     /// Converts Twitter ImageType to Gravatar as Twitter API is no longer available
     private static ImageType SanitizeImageType(ImageType imageType)
     {
-        return imageType.ToString() == "Twitter" ? ImageType.Gravatar : imageType;
+        return imageType == ImageType.Twitter ? ImageType.Gravatar : imageType;
     }
 }

--- a/headapps/MvpSite/MvpSite.Rendering/ViewComponents/Any/MyDataEditViewComponent.cs
+++ b/headapps/MvpSite/MvpSite.Rendering/ViewComponents/Any/MyDataEditViewComponent.cs
@@ -28,7 +28,9 @@ public class MyDataEditViewComponent(IViewModelBinder modelBinder, MvpSelections
                     Name = model.Name ?? string.Empty,
                     Email = model.Email ?? string.Empty,
                     Country = new Country(model.CountryId),
-                    ImageType = model.ImageType
+
+                    // Clear Twitter ImageType if selected, as Twitter API is no longer available
+                    ImageType = model.ImageType.ToString() == "Twitter" ? ImageType.Gravatar : model.ImageType
                 };
 
                 userResponse = await Client.UpdateCurrentUserAsync(updatedUser);
@@ -44,7 +46,9 @@ public class MyDataEditViewComponent(IViewModelBinder modelBinder, MvpSelections
                 model.Name = user.Name;
                 model.Email = user.Email;
                 model.CountryId = user.Country?.Id ?? 0;
-                model.ImageType = user.ImageType;
+
+                // Clear Twitter ImageType if selected, as Twitter API is no longer available
+                model.ImageType = user.ImageType.ToString() == "Twitter" ? ImageType.Gravatar : user.ImageType;
                 model.ImageUri = user.ImageUri;
                 ModelState.Clear();
             }

--- a/headapps/MvpSite/MvpSite.Rendering/ViewComponents/Any/MyDataEditViewComponent.cs
+++ b/headapps/MvpSite/MvpSite.Rendering/ViewComponents/Any/MyDataEditViewComponent.cs
@@ -75,10 +75,10 @@ public class MyDataEditViewComponent(IViewModelBinder modelBinder, MvpSelections
         return result;
     }
 
-    /// Converts Twitter ImageType to Gravatar as Twitter API is no longer available
+    /// Converts Twitter ImageType to Anonymous as Twitter API is no longer available
     private static ImageType SanitizeImageType(ImageType imageType)
     {
-        return imageType == ImageType.Twitter ? ImageType.Gravatar : imageType;
+        return imageType == ImageType.Twitter ? ImageType.Anonymous : imageType;
     }
 
     private async Task LoadCountries(MyDataEditModel model)

--- a/headapps/MvpSite/MvpSite.Rendering/ViewComponents/Any/MyDataEditViewComponent.cs
+++ b/headapps/MvpSite/MvpSite.Rendering/ViewComponents/Any/MyDataEditViewComponent.cs
@@ -30,7 +30,7 @@ public class MyDataEditViewComponent(IViewModelBinder modelBinder, MvpSelections
                     Country = new Country(model.CountryId),
 
                     // Clear Twitter ImageType if selected, as Twitter API is no longer available
-                    ImageType = model.ImageType.ToString() == "Twitter" ? ImageType.Gravatar : model.ImageType
+                    ImageType = SanitizeImageType(model.ImageType)
                 };
 
                 userResponse = await Client.UpdateCurrentUserAsync(updatedUser);
@@ -48,7 +48,7 @@ public class MyDataEditViewComponent(IViewModelBinder modelBinder, MvpSelections
                 model.CountryId = user.Country?.Id ?? 0;
 
                 // Clear Twitter ImageType if selected, as Twitter API is no longer available
-                model.ImageType = user.ImageType.ToString() == "Twitter" ? ImageType.Gravatar : user.ImageType;
+                model.ImageType = SanitizeImageType(user.ImageType);
                 model.ImageUri = user.ImageUri;
                 ModelState.Clear();
             }
@@ -91,5 +91,11 @@ public class MyDataEditViewComponent(IViewModelBinder modelBinder, MvpSelections
         {
             model.Consents.AddRange(consentResponse.Result);
         }
+    }
+
+    /// Converts Twitter ImageType to Gravatar as Twitter API is no longer available
+    private static ImageType SanitizeImageType(ImageType imageType)
+    {
+        return imageType.ToString() == "Twitter" ? ImageType.Gravatar : imageType;
     }
 }

--- a/headapps/MvpSite/MvpSite.Rendering/ViewComponents/Any/MyDataEditViewComponent.cs
+++ b/headapps/MvpSite/MvpSite.Rendering/ViewComponents/Any/MyDataEditViewComponent.cs
@@ -75,6 +75,12 @@ public class MyDataEditViewComponent(IViewModelBinder modelBinder, MvpSelections
         return result;
     }
 
+    /// Converts Twitter ImageType to Gravatar as Twitter API is no longer available
+    private static ImageType SanitizeImageType(ImageType imageType)
+    {
+        return imageType == ImageType.Twitter ? ImageType.Gravatar : imageType;
+    }
+
     private async Task LoadCountries(MyDataEditModel model)
     {
         Response<IList<Country>> countryResponse = await Client.GetCountriesAsync(1, short.MaxValue);
@@ -91,11 +97,5 @@ public class MyDataEditViewComponent(IViewModelBinder modelBinder, MvpSelections
         {
             model.Consents.AddRange(consentResponse.Result);
         }
-    }
-
-    /// Converts Twitter ImageType to Gravatar as Twitter API is no longer available
-    private static ImageType SanitizeImageType(ImageType imageType)
-    {
-        return imageType == ImageType.Twitter ? ImageType.Gravatar : imageType;
     }
 }

--- a/headapps/MvpSite/MvpSite.Rendering/Views/Shared/Components/AnyMyDataEdit/Default.cshtml
+++ b/headapps/MvpSite/MvpSite.Rendering/Views/Shared/Components/AnyMyDataEdit/Default.cshtml
@@ -48,7 +48,7 @@
                     @foreach (ImageType imageType in Enum.GetValues<ImageType>())
                     {
                         @* Exclude Twitter option as Twitter API is no longer available *@
-                        @if (imageType.ToString() != "Twitter")
+                        @if (imageType != ImageType.Twitter)
                         {
                             <option value="@imageType">@imageType</option>
                         }

--- a/headapps/MvpSite/MvpSite.Rendering/Views/Shared/Components/AnyMyDataEdit/Default.cshtml
+++ b/headapps/MvpSite/MvpSite.Rendering/Views/Shared/Components/AnyMyDataEdit/Default.cshtml
@@ -47,7 +47,11 @@
                 <select asp-for="ImageType" class="form-control" required>
                     @foreach (ImageType imageType in Enum.GetValues<ImageType>())
                     {
-                        <option value="@imageType">@imageType</option>
+                        @* Exclude Twitter option as Twitter API is no longer available *@
+                        @if (imageType.ToString() != "Twitter")
+                        {
+                            <option value="@imageType">@imageType</option>
+                        }
                     }
                 </select>
                 <span asp-validation-for="ImageType" class="text-danger"></span>

--- a/headapps/MvpSite/MvpSite.Rendering/Views/Shared/Components/AnyMyDataEdit/Default.cshtml
+++ b/headapps/MvpSite/MvpSite.Rendering/Views/Shared/Components/AnyMyDataEdit/Default.cshtml
@@ -45,13 +45,10 @@
                 </label>
                 <span class="text-danger">*</span>
                 <select asp-for="ImageType" class="form-control" required>
-                    @foreach (ImageType imageType in Enum.GetValues<ImageType>())
+                    @* Exclude Twitter option as Twitter API is no longer available *@
+                    @foreach (ImageType imageType in Enum.GetValues<ImageType>().Where(x => x != ImageType.Twitter))
                     {
-                        @* Exclude Twitter option as Twitter API is no longer available *@
-                        @if (imageType != ImageType.Twitter)
-                        {
-                            <option value="@imageType">@imageType</option>
-                        }
+                        <option value="@imageType">@imageType</option>
                     }
                 </select>
                 <span asp-validation-for="ImageType" class="text-danger"></span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation

- Hide Twitter option from profile image dropdown
- Convert existing Twitter selections to Anonymous automatically  
- Apply Twitter-to-Anonymous conversion on load and save operations
- Fix errors for users who previously selected Twitter as image

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manual UI Testing in localhost running app

https://github.com/user-attachments/assets/5d82983e-fe91-4465-b080-f9feb07a83f5


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.

## Related Issue

Closes #349