### PR TITLE
Fix for Remove Timeline if no item is listed #545

### DIFF
--- a/headapps/MvpSite/MvpSite.Rendering/Views/Shared/Components/Profile/Default.cshtml
+++ b/headapps/MvpSite/MvpSite.Rendering/Views/Shared/Components/Profile/Default.cshtml
@@ -44,11 +44,14 @@
                 <partial name="Components/Profile/_Mentor" model="Model" />
             </div>
         }
-        <div class="container timeline ">
-            <div class="row inner mb-5">
-            <h3 asp-for="TimelineLabel" class="col-12"></h3>
-            <partial name="Components/Profile/_Timeline" model="Model.GetTimelineEvents()" />
-        </div>
-        </div>
+        @if (Model.GetTimelineEvents()?.Any() == true)
+        {
+            <div class="container timeline ">
+                <div class="row inner mb-5">
+                    <h3 asp-for="TimelineLabel" class="col-12"></h3>
+                    <partial name="Components/Profile/_Timeline" model="Model.GetTimelineEvents()" />
+                </div>
+            </div>
+        }
     </section>
 }

--- a/headapps/MvpSite/MvpSite.Rendering/Views/Shared/Components/Profile/Default.cshtml
+++ b/headapps/MvpSite/MvpSite.Rendering/Views/Shared/Components/Profile/Default.cshtml
@@ -44,7 +44,7 @@
                 <partial name="Components/Profile/_Mentor" model="Model" />
             </div>
         }
-        @if (Model.GetTimelineEvents()?.Any() == true)
+        @if ((Model.GetTimelineEvents()?.Any() ?? false))
         {
             <div class="container timeline ">
                 <div class="row inner mb-5">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation

This change updates the Razor view to ensure that the timeline section is only rendered when there are timeline events available. Previously, the timeline container was always rendered, even if no events were present, which could result in empty or misleading UI sections.

This improves the user experience by displaying relevant content only when available and avoids rendering unnecessary HTML markup.

## How Has This Been Tested?

- Manually tested the profile view with and without timeline events.
**Verified that:**
- The timeline section appears only when Model.GetTimelineEvents() returns items.
- The section is hidden when the timeline is empty or null.
- Tested in local development environment using Visual Studio 2022.
- Confirmed that no layout or styling issues occur due to conditional rendering.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.