### PR TITLE
Re added dependency on Experience Editor, due to lack of SXA

### DIFF
--- a/headapps/MvpSite/Directory.Packages.props
+++ b/headapps/MvpSite/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="Sitecore.AspNetCore.SDK.LayoutService.Client" Version="$(AspNetCoreSdkVersion)" />
     <PackageVersion Include="Sitecore.AspNetCore.SDK.Pages" Version="$(AspNetCoreSdkVersion)" />
     <PackageVersion Include="Sitecore.AspNetCore.SDK.RenderingEngine" Version="$(AspNetCoreSdkVersion)" />
+
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageVersion Include="System.ServiceModel.Syndication" Version="8.0.0" />

--- a/headapps/MvpSite/MvpSite.Rendering/Program.cs
+++ b/headapps/MvpSite/MvpSite.Rendering/Program.cs
@@ -78,14 +78,7 @@ builder.Services.AddSitecoreRenderingEngine(options =>
     .ForwardHeaders()
 
     // Enable support for the Page Editor.
-    .WithSitecorePages(sitecoreSettings.EdgeContextId!, Options);
-
-void Options(PagesOptions obj)
-{
-    throw new NotImplementedException();
-}
-
-options => { options.EditingSecret = sitecoreSettings.EditingSecret; });
+    .WithSitecorePages(sitecoreSettings.EdgeContextId!, options => { options.EditingSecret = sitecoreSettings.EditingSecret; });
 
 // Register MVP Functionality specific services
 builder.Services.AddFeatureSocialServices()


### PR DESCRIPTION
The MVP site not being created with SXA means we can't leverage the RenderingHost functionality for metadata connection to an external editing host.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.

Closes #551 