### PR TITLE
Disable X-Frame check when in editing mode

### DIFF
--- a/headapps/MvpSite/MvpSite.Rendering/Program.cs
+++ b/headapps/MvpSite/MvpSite.Rendering/Program.cs
@@ -87,6 +87,12 @@ builder.Services.AddFeatureSocialServices()
 
 builder.Services.AddSession();
 
+// If we're in edit mode we need to disable X-Frame to let pages render forms outside `sameorigin` policy.
+if (sitecoreSettings.EnableEditingMode)
+{
+    builder.Services.AddAntiforgery(o => o.SuppressXFrameOptionsHeader = true);
+}
+
 // The following line enables Application Insights telemetry collection.
 builder.Services.AddApplicationInsightsTelemetry();
 


### PR DESCRIPTION
We need to disable the X-FRAME sameorigin policy when the app is deployed in editing mode, as Pages can't render any pages that contain Form tags currently.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.

Closes #550