### PR TITLE
Added community.sitecore.com to CSP img-src directive

### DIFF
--- a/headapps/MvpSite/MvpSite.Rendering/Extensions/ApplicationBuilderExtensions.cs
+++ b/headapps/MvpSite/MvpSite.Rendering/Extensions/ApplicationBuilderExtensions.cs
@@ -51,7 +51,8 @@ public static class ApplicationBuilderExtensions
             cspBuilder.Append("https://www.googletagmanager.com ");
             cspBuilder.Append("https://www.google-analytics.com ");
             cspBuilder.Append("https://*.sitecorecloud.io ");   
-            cspBuilder.Append("https://www.gravatar.com ");
+            cspBuilder.Append("https://www.gravatar.com ");            
+            cspBuilder.Append("https://community.sitecore.com ");
             cspBuilder.Append("https://delivery-sitecore.sitecorecontenthub.cloud; ");
 
             cspBuilder.Append("font-src 'self' ");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation

Added `https://community.sitecore.com` to the CSP img-src directive to fix avatar photo blocking. Avatar images from `community.sitecore.com` were being blocked by the Content Security Policy, causing profile photos to fail to load on MVP profile pages.

Related Issue: #593 

## How Has This Been Tested?

1. Navigate to a [profile page](https://mvp.sitecore.com/en/Directory/Profile?id=2b70387b4b2940c8d1af08de30994791) that displays avatar photo from community.sitecore.com
2. Verify that avatar images load successfully without CSP violations in the browser console


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.